### PR TITLE
[Claude] 新增 WORK_BOARD.md：工作認領表，避免重工

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,18 @@ Claude，先讀 `CLAUDE.md`；這份是通用規則，兩者都要遵守。
 
 ---
 
+## 零、開始新工作前——先查 `WORK_BOARD.md`
+
+**2026-08-12 起新增**：起因是 Codex 接續了 Claude 稍早卡住的多星團驗證
+工作，兩邊動到同一個檔案，事後才發現是接續、不是重工，但這種事本來
+應該一開始就能避免。任何預期會花超過一次對話、或會碰共用檔案
+（`pipeline/`、`injection_recovery.py`、`LIMITATIONS.md`、
+`PAPER_OUTLINE.md`、`queue.txt`）的工作，**開始前先讀
+`WORK_BOARD.md`，確認沒有人已經在做同一件事**；開始時在裡面認領一行。
+看不出算不算重複就直接編輯那份文件寫清楚疑點，不要用猜的。
+
+---
+
 ## 一、分支與 Pull Request——所有人都要走 PR，沒有例外
 
 `main` 分支設了保護規則：**任何人（含 repo 擁有者）都不能直接 push 到

--- a/WORK_BOARD.md
+++ b/WORK_BOARD.md
@@ -1,0 +1,42 @@
+# 工作認領表（誰現在在做什麼）
+
+`CONTRIBUTING.md` 管「怎麼合併」，這份管**「開始做之前先看這裡，避免兩個人／
+兩個 agent 同時做同一件事」**。跟 `results/RESULTS_LOG.md` 一樣設計成
+**只附加、不改舊行**的格式——多人同時寫幾乎不會撞行，不需要鎖檔案。
+
+## 規則
+
+1. **開始任何預期要花超過一次對話（或會碰共用檔案：`pipeline/`、
+   `injection_recovery.py`、`LIMITATIONS.md`、`PAPER_OUTLINE.md`、
+   `queue.txt`）的工作之前**，先讀完下面的表格，確認沒有人已經在做
+   同一件事或高度重疊的事。
+2. 開始工作時，在表格**尾端加一行**，狀態填「進行中」。做完、暫停、
+   或放棄時，**再加一行新的**（同任務名稱、狀態改掉），不要回頭改舊行——
+   要查某任務目前狀態，從下往上找同名任務最新的一行。
+3. **看不出算不算重複、範圍該怎麼分**——不要用猜的、也不要因為怕
+   衝突就不寫：直接在表格加一行「疑義」狀態並寫清楚困惑點，讓開這個
+   任務的人或使用者看到後決定怎麼分工。這比「先做了再說」風險小。
+4. 誰都可以編輯這份文件（人類協作者、Claude、Codex、其他 agent）。
+
+## 欄位
+
+| 日期 | 執行者 | 任務名稱 | 狀態 | 涉及檔案／分支 | 備註 |
+|---|---|---|---|---|---|
+
+## 紀錄
+
+| 日期 | 執行者 | 任務名稱 | 狀態 | 涉及檔案／分支 | 備註 |
+|---|---|---|---|---|---|
+| 2026-08-11 13:35 | Claude session（本機） | 多星團 Tier1：NGC 3532／Praesepe 起頭 | 暫停（卡住） | `cluster_imf_tier1.py`、`data/hr23_*`，commit `4fd8c67` | 已抓 HR23 成員表並存檔，PARSEC 等時線服務（stev.oapd.inaf.it）連續 6 次 SSL 交握斷線，卡在這裡；`LIMITATIONS.md` 已記錄，含之後要重跑的指令 |
+| 2026-08-11 19:31–20:14 | Codex | 多星團通用性驗證：NGC 3532／Praesepe（Tier1 傳統法 + Tier2 前向模型全套） | 完成，PR #11（draft，待審） | `cluster_imf_tier1.py`（延伸）、新增 `prepare_cluster_tier2.py`、`cluster_forward_validation.py`、`MULTICLUSTER_VALIDATION.md`，分支 `codex/ngc3532-praesepe-generalization` | **接續上一行**、不是獨立重做——用本機已快取的等時線網格繞過 PARSEC 卡點（沒有重新呼叫 PARSEC 服務），把 Tier1 沒做完的補完，還加了 Tier2（Gaia crossmatch＋誤差模型＋選擇函數＋完整 JointModel 前向模型）。這條在 PR 審查通過前先標記，之後補結論 |
+| 2026-08-12 | Claude session（本機） | 建立本工作認領表，回填上面兩筆已知的重疊/接續紀錄 | 完成 | `WORK_BOARD.md`（新檔） | 起因：使用者發現 Codex 的 PR #11 跟自己稍早的多星團工作動到同一個檔案，追問是否重複；查證後確認是接續而非重工，見上兩行 |
+
+## 目前已知的固定分工（不用每次都查表）
+
+- **本機 8 核運算佇列**（`queue.txt` / `run_queue.py`，Windows ARM64 這台機器）
+  只有這台機器能跑，其他人／agent 不會撞到，不需要在此認領。目前跑到
+  `verify_bprperr_off`，後面排 `verify_bprperr_on`、`p2_free_lowmass`、
+  `p6_lowmass_v2`、`p11_outlierfrac_v2`。
+- 若要在別的機器（Kaggle、同學的電腦、Codex 的環境）重跑本機佇列裡
+  同一個腳本、同一組參數，**先在這裡加一行認領**，避免兩邊各自跑一次
+  浪費算力、之後也不知道該採哪一份結果。


### PR DESCRIPTION
## What changed
- 新增 `WORK_BOARD.md`：附加式工作認領紀錄，仿 `results/RESULTS_LOG.md` 已驗證過的低衝突格式。
- `CONTRIBUTING.md` 加第零節指向它。

## Why
使用者發現 PR #11（Codex）跟這個 session 稍早卡住的多星團 Tier1 工作動到同一個檔案，追問是否重複。查證後確認是接續（Codex 用已快取的等時線網格繞過我卡住的 PARSEC 問題），不是重工，但暴露出協作流程缺一個「開始前先看誰在做什麼」的機制。

## Results and impact
不影響任何計算結果，純文件／流程變更。已在 WORK_BOARD.md 回填 PR #11 與稍早那筆工作的重疊/接續關係。

🤖 Generated with [Claude Code](https://claude.com/claude-code)