### PR TITLE
[Claude] 加入 CodeRabbit 設定，公開 repo 免費自動審 PR

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,42 @@
+# CodeRabbit 設定（免費方案，公開 repo 自動適用）。
+# 安裝步驟見 PR 說明／README——這份檔案只負責「裝好之後怎麼審」，
+# 不含任何金鑰，安裝本身要用你自己的 GitHub 帳號在 coderabbit.ai 授權。
+language: "zh-TW"
+
+reviews:
+  profile: "chill"
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    # 結果檔案（.npz/.csv/.json）跟快取的等時線網格不是給人看 diff 的，
+    # 審這些只會製造噪音，排除掉。
+    - "!results/**"
+    - "!data/**"
+    - "!isochrones/**"
+    - "!logs/**"
+    - "!kaggle_work/**"
+  path_instructions:
+    - path: "injection_recovery.py"
+      instructions: >
+        multi_stage_best() 是這個專案共用的網格精修核心，被 fit_real.py／
+        profile_lowmass.py／profile_outlierfrac.py／inject_lowmass.py 等
+        生產腳本呼叫。2026-08-11 這裡曾經有過「refines 只給單一值時完全
+        沒精修」的 bug（已修好）。任何改動這個函式的 PR，優先檢查：
+        (1) 新參數的預設值是否讓既有呼叫者行為完全不變；
+        (2) 精修迴圈是否每一階都真的重新呼叫 grid_best_parallel。
+    - path: "pipeline/**"
+      instructions: >
+        這是 M45 前向模型的核心套件，被多個生產腳本共用。任何新增的
+        cluster-specific 腳本（cluster_*.py）如果需要類似邏輯，優先檢查
+        是否該在這裡加通用參數，而不是在呼叫端重新實作一份。
+    - path: "LIMITATIONS.md"
+      instructions: >
+        這份檔案有明確的待辦分類標準（見 CLAUDE.md）：會影響已產出結果、
+        或改變論文結論方向的問題要標成「現役缺陷」並附優先度，不能跟一般
+        待辦敏感度測試混在一起排隊。審查時確認新增內容有沒有誤判成低優先。
+
+chat:
+  auto_reply: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,25 @@ Claude，先讀 `CLAUDE.md`；這份是通用規則，兩者都要遵守。
 
 ---
 
+## 零之一、自動 PR 審查——CodeRabbit（免費，公開 repo 自動適用）
+
+**2026-08-12 起**：repo 公開後，[CodeRabbit](https://coderabbit.ai) 對公開
+repo 免費。裝好之後，**任何人開 PR 都會自動觸發一次審查留言**，不需要
+另外呼叫誰。設定檔在 `.coderabbit.yaml`（審查語言、排除 `results/`／
+`data/` 這類資料檔、對 `injection_recovery.py`／`pipeline/` 等共用核心
+給的審查提示）。
+
+**啟用需要 repo 擁有者做一次性的手動步驟**（Claude／agent 無法代勞，
+這是帳號授權操作）：到 https://github.com/apps/coderabbitai 或
+https://coderabbit.ai 用 GitHub 帳號登入，安裝 App 並選這個 repo。
+裝好後不需要金鑰、不需要額外設定，`.coderabbit.yaml` 會自動生效。
+
+CodeRabbit 的審查是**輔助**，不是取代 `WORK_BOARD.md`／PR review 流程——
+它抓程式面的問題（bug、重複實作、效率），跑不動這個專案的實際計算，
+數字對不對還是要靠 `results/RESULTS_LOG.md` 跟人／其他 agent 交叉核對。
+
+---
+
 ## 一、分支與 Pull Request——所有人都要走 PR，沒有例外
 
 `main` 分支設了保護規則：**任何人（含 repo 擁有者）都不能直接 push 到


### PR DESCRIPTION
## What changed
- 新增 `.coderabbit.yaml`：審查語言 zh-TW，排除 `results/`／`data/`／`isochrones/`／`logs/`／`kaggle_work/` 這類資料檔，對 `injection_recovery.py`／`pipeline/`／`LIMITATIONS.md` 給路徑專屬的審查提示。
- `CONTRIBUTING.md` 加第零之一節說明用途與啟用方式。

## Why
使用者要求把「PR 開的時候自動審核」改成免費的 CodeRabbit，取代原本討論的 Claude GitHub Action 方案（同樣跑在 GitHub 側，但不需要管理 API 金鑰，公開 repo 免費）。

## 還差一步（我做不到，需要 repo 擁有者本人）
到 https://github.com/apps/coderabbitai 或 https://coderabbit.ai 用 GitHub 帳號登入、安裝 App、選這個 repo。這是帳號授權操作，agent 不能代勞。裝完不需要金鑰，這個 PR 裡的設定檔會自動生效。

## Results and impact
不影響任何計算結果，純設定/文件變更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)