### PR TITLE
[Claude] 修正 fetch_gaia.py 寫死原作者本機路徑

### DIFF
--- a/fetch_gaia.py
+++ b/fetch_gaia.py
@@ -10,26 +10,36 @@ import sys
 from pathlib import Path
 
 HERE = Path(__file__).parent
+DATA = HERE / "data"
 
-# gaia-export 是姊妹專案（github.com/helmet-png/gaia-dr3-export），不同機器
-# clone 的位置不一樣，依序試：環境變數 > 跟這個 repo 同一層的常見資料夾名稱 >
-# 原作者機器上的寫死路徑（相容舊設定）。
-_CANDIDATES = [os.environ.get("GAIA_EXPORT_PATH")] + [
-    HERE.parent / name for name in ("gaia-dr3-export", "gaia-export")
-] + [Path(r"C:\Users\Alber\Claude\gaia-export")]
-for _c in _CANDIDATES:
-    if _c and Path(_c).is_dir():
-        GAIA_EXPORT = Path(_c)
-        break
-else:
+
+def _load_server():
+    """找到 gaia-export 姊妹專案並匯入它的 server.py，回傳該模組。
+
+    gaia-export（github.com/helmet-png/gaia-dr3-export）不同機器 clone
+    的位置不一樣，依序試：環境變數 > 跟這個 repo 同一層的常見資料夾名稱 >
+    原作者機器上的寫死路徑（相容舊設定）。只認有 server.py 的目錄，避免
+    誤選到同名但不對的資料夾。
+
+    延後到這裡才做（不是 module 頂層），這樣 --help 或單純 import 這個
+    檔案不會因為找不到 gaia-export 就整個炸掉。
+    """
+    candidates = [os.environ.get("GAIA_EXPORT_PATH")] + [
+        HERE.parent / name for name in ("gaia-dr3-export", "gaia-export")
+    ] + [r"C:\Users\Alber\Claude\gaia-export"]
+    for c in candidates:
+        if not c:
+            continue
+        c = Path(c)
+        if c.is_dir() and (c / "server.py").is_file():
+            sys.path.insert(0, str(c))
+            import server
+            return server
     raise FileNotFoundError(
-        "找不到 gaia-export 專案（server.py 所在目錄）。"
+        "找不到 gaia-export 專案（含 server.py 的目錄）。"
         "設定環境變數 GAIA_EXPORT_PATH 指向它，或把它 clone 到跟本 repo 同一層"
         "（github.com/helmet-png/gaia-dr3-export）。"
     )
-sys.path.insert(0, str(GAIA_EXPORT))
-import server  # noqa: E402
-DATA = HERE / "data"
 
 # 分群要用的三個量＋其誤差；光度與品質欄位供第 2、3 步用，不參與分群。
 # flux_over_error 是必要的：前向模型要生成合成星團時，得知道真實觀測的測光
@@ -58,6 +68,7 @@ def main():
                     help="視差下限（mas）；給 0 表示不切，對照跑用")
     ap.add_argument("--force", action="store_true", help="已有檔案也重抓")
     a = ap.parse_args()
+    server = _load_server()
 
     DATA.mkdir(exist_ok=True)
     tag = a.target.lower().replace(" ", "")

--- a/fetch_gaia.py
+++ b/fetch_gaia.py
@@ -5,14 +5,30 @@ TAP 那層直接沿用 gaia-export 專案的 server.py（含 sync→async fallba
 不另外實作一套。
 """
 import argparse
+import os
 import sys
 from pathlib import Path
 
-GAIA_EXPORT = Path(r"C:\Users\Alber\Claude\gaia-export")
+HERE = Path(__file__).parent
+
+# gaia-export 是姊妹專案（github.com/helmet-png/gaia-dr3-export），不同機器
+# clone 的位置不一樣，依序試：環境變數 > 跟這個 repo 同一層的常見資料夾名稱 >
+# 原作者機器上的寫死路徑（相容舊設定）。
+_CANDIDATES = [os.environ.get("GAIA_EXPORT_PATH")] + [
+    HERE.parent / name for name in ("gaia-dr3-export", "gaia-export")
+] + [Path(r"C:\Users\Alber\Claude\gaia-export")]
+for _c in _CANDIDATES:
+    if _c and Path(_c).is_dir():
+        GAIA_EXPORT = Path(_c)
+        break
+else:
+    raise FileNotFoundError(
+        "找不到 gaia-export 專案（server.py 所在目錄）。"
+        "設定環境變數 GAIA_EXPORT_PATH 指向它，或把它 clone 到跟本 repo 同一層"
+        "（github.com/helmet-png/gaia-dr3-export）。"
+    )
 sys.path.insert(0, str(GAIA_EXPORT))
 import server  # noqa: E402
-
-HERE = Path(__file__).parent
 DATA = HERE / "data"
 
 # 分群要用的三個量＋其誤差；光度與品質欄位供第 2、3 步用，不參與分群。


### PR DESCRIPTION
## 問題
`fetch_gaia.py` 的 `GAIA_EXPORT` 寫死 `C:\\Users\\Alber\\Claude\\gaia-export`，只有原作者的機器能跑，其他協作者的機器 `import server` 會直接 `ModuleNotFoundError`，完全無法重新抓取 Gaia 原始資料。

## 修法
依序嘗試：環境變數 `GAIA_EXPORT_PATH` → 跟本 repo 同層的 `gaia-dr3-export`/`gaia-export` 資料夾 → 原本寫死的路徑（相容舆舊設定）。都找不到才報清楚的錯誤訊息，不吃掉錯誤。

## 驗證
在新的協作者機器上（clone `github.com/helmet-png/gaia-dr3-export` 到與本 repo 同層目錄），實測 `python fetch_gaia.py --target M45 --radius 5 --gmax 18 --plxmin 4`：

```
M45 -> RA=56.60083, Dec=24.11389
符合條件：6,956 顆
寫入 data/m45_r5_g18_plx4.csv（6,956 列，1,631,385 bytes）
```

6,956 顆與 `README.md`／`LIMITATIONS.md` 記錄的既有數字完全一致。

另外用同一台機器的既有 `data/cmd_members.csv` 跑了 `run_pipeline.py --steps 3 4 5`（第 1 步用 repo 裡已有的 `results/baseline.dat`），headline 數字（f_bin=0.45、四法標記數 414/100/58/24、alpha_naive=1.980±0.069、alpha_forward=2.350、質量分層 α(r)）都與 README.md 記錄一致，沒有 commit 這些重跑輸出。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup reliability by automatically locating the Gaia export project through configured, nearby, or legacy paths.
  * Added a clear error message when the required project cannot be found.
  * The tool can now be imported and its help information viewed without the Gaia export project installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->