### PR TITLE
[Claude] Kaggle 掛載問題：接手交接，匯名部分排除平台異常假設

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -468,6 +468,30 @@ Kaggle 官方追查到是 notebook 編輯器背後用的 **Google Firebase 服�
 底下的全域參考文件，不在這個 repo 裡，其他機器上的 agent 讀不到，
 需要另外建置或參考本節內容重建**）。
 
+**2026-08-12（新機器接手，第 1 點部分排除）**：另一台機器的 Claude
+session 接手這個交接，但**沒有可用的 Kaggle 帳號**（AI agent 本身不能
+建立帳號，這是明確的操作限制），所以只能先做不需要登入的第 1 點。
+用瀏覽器工具匿名開了兩個現成 public notebook（`kaggle.com/code` 列表
+裡隨機挑的，非固定 URL）：`/code` 列表頁、單一 notebook 的檢視頁
+（`tonyashrafmounir/students-performance`，Notebook/Input/Output/Logs/
+Comments 五個分頁、側欄、TOC 錨點都正常渲染，Logs 分頁顯示上一次
+執行「32.9 second run - successful」）——**沒有出現「Editor loading」
+卡死的畫面，前端渲染與互動都正常**。
+
+**這只能算部分排除第 1 點，不是完全排除**：匿名檢視的是唯讀頁面，
+不是使用者先前卡住的那個已登入、可編輯的 Notebook Editor（`Copy & Edit`
+按鈕本身就會導去登入頁，無法在匿名狀態下測試）。但至少證實 Kaggle
+的前端服務與這個唯讀 notebook 渲染路徑（很可能與編輯器共用底層
+基礎設施）**現在（2026-08-12）沒有明顯異常**，跟先前「Firebase
+服務出問題」的猜測不衝突（那類問題通常會隨時間自行恢復）。
+
+**第 2、3 點仍卡在需要真實 Kaggle 帳號才能繼續**：這兩點都要登入、
+手動操作網頁版 Notebook（Add Input／檢查 `/kaggle/input`），或用
+API token 跑 `kaggle_queue.py` 這類自動化，AI agent 都做不到（不能
+建帳號、不能持有登入密碼）。需要使用者提供一個新帳號的 API token
+（走現有的 `kaggle_accounts.json` 模式，不是登入網頁），或使用者
+自己動手做第 2 點的網頁手動測試再回報結果。
+
 ### 低質量段冪次被固定，而它佔了六成的樣本（2026-08-07 新增，嚴重）
 
 前向模型的 `alpha` **只是 Kroupa 分段冪律裡 m > 0.5 M☉ 那一段的冪次**。

--- a/WORK_BOARD.md
+++ b/WORK_BOARD.md
@@ -31,6 +31,7 @@
 | 2026-08-11 19:31–20:14 | Codex | 多星團通用性驗證：NGC 3532／Praesepe（Tier1 傳統法 + Tier2 前向模型全套） | 完成，PR #11（draft，待審） | `cluster_imf_tier1.py`（延伸）、新增 `prepare_cluster_tier2.py`、`cluster_forward_validation.py`、`MULTICLUSTER_VALIDATION.md`，分支 `codex/ngc3532-praesepe-generalization` | **接續上一行**、不是獨立重做——用本機已快取的等時線網格繞過 PARSEC 卡點（沒有重新呼叫 PARSEC 服務），把 Tier1 沒做完的補完，還加了 Tier2（Gaia crossmatch＋誤差模型＋選擇函數＋完整 JointModel 前向模型）。這條在 PR 審查通過前先標記，之後補結論 |
 | 2026-08-12 | Claude session（本機） | 建立本工作認領表，回填上面兩筆已知的重疊/接續紀錄 | 完成 | `WORK_BOARD.md`（新檔） | 起因：使用者發現 Codex 的 PR #11 跟自己稍早的多星團工作動到同一個檔案，追問是否重複；查證後確認是接續而非重工，見上兩行 |
 | 2026-08-12 | Claude session（本機，交接給另一台電腦的 agent） | Kaggle dataset 掛載問題根因排查（見 `LIMITATIONS.md`「Kaggle 掛載問題根因排查」一節） | 交接中，等另一台機器用不同帳號接手 | `LIMITATIONS.md`、`kaggle_queue.txt`、`kaggle_sync.py`（已加 in-kernel 等待，不用再改）、`kaggle_accounts.json`（不進版控，新 agent 要自己建） | 本機已排除「純時序」「帳號未驗證」兩個假設；使用者實測發現 Kaggle 網頁版 Notebook Editor 本身卡在「Editor loading」，換瀏覽器/無痕都無效，懷疑是 Kaggle 平台（可能是 Firebase 服務）暫時異常，不是帳號或我們程式的問題，但這個假設也還沒證實。**交接給另一台電腦、用另一個 Kaggle 帳號**測試是為了排除「同一帳號被限制」這個殘餘可能性，兩台機器同時測也能交叉驗證是不是平台性問題。新 agent 開始前**先讀 `LIMITATIONS.md` 那一節的完整診斷過程**，不要重新從頭排查已經排除的假設 |
+| 2026-08-12 | Claude session（新機器，x64，接手交接） | Kaggle dataset 掛載問題根因排查（接續上一行） | 進行中，卡在需要真實 Kaggle 帳號 | `LIMITATIONS.md`（已補「2026-08-12（新機器接手，第 1 點部分排除）」段落） | 用瀏覽器工具匿名測了「下一步該查」第 1 點（Kaggle 平台本身是否異常）：兩個現成 public notebook 頁面渲染正常、無「Editor loading」卡死，**部分排除**平台異常（只測到唯讀頁面，不是已登入的 Editor，不算完全排除）。第 2、3 點需要真實 Kaggle 帳號（登入操作或 API token）才能繼續，AI agent 不能建立帳號／持有密碼，已回報使用者請求提供新帳號的 API token 或請使用者自行手動測第 2 點 |
 
 ## 目前已知的固定分工（不用每次都查表）
 


### PR DESCRIPTION
接續 `WORK_BOARD.md` 交接的 Kaggle dataset 掛載問題根因排查。

## 做了什麼
這台新機器沒有可用的 Kaggle 帳號（AI agent 不能建立帳號、不能持有登入密碼），所以只能先做 `LIMITATIONS.md`「下一步該查的」第 1 點（不需要登入）：用瀏覽器工具匯名開兩個現成 public notebook，確認 Kaggle 前端渲染是否正常。

## 發現
`/code` 列表頁與單一 notebook 檢視頁（Notebook/Input/Output/Logs/Comments 五分頁、側欄、TOC）都正常渲染，沒有「Editor loading」卡死，Logs 顯示上次執行成功。**部分排除**平台異常假設——測的是匯名唇讀頁面，不是已登入可編輯的 Notebook Editor（Copy & Edit 會導去登入頁，匯名測不到），所以不算完全排除。

## 還卡住的地方
第 2、3 點（網頁手動測試 Add Input、帳號層級限制排查）需要真實帳號才能繼續，AI agent 做不到。已在 `LIMITATIONS.md` 與 `WORK_BOARD.md` 記錄卡點，回報使用者需要提供新帳號的 API token（走現有 `kaggle_accounts.json` 模式，不是登入網頁）或使用者自己動手做網頁手動測試。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a dated handoff record for the Kaggle dataset mounting investigation.
  * Documented that public notebook viewing showed no apparent frontend or read-only rendering issues.
  * Recorded remaining authentication requirements and follow-up steps for signed-in notebook testing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->