### PR TITLE
[Claude] 修正 Kaggle 派工從沒建立 results/ 導致存檔失敗的嚴重 bug

### DIFF
--- a/kaggle_sync.py
+++ b/kaggle_sync.py
@@ -196,7 +196,14 @@ def make_kernel(script: str, args: str, dataset_id: str, username: str,
         "        time.sleep(interval)\n",
         f"_wait_input('{base}{'pipeline' if not minimal else script}')\n",
     ]
-    copy_lines = [f"shutil.copy('{base}{script}', '{script}')\n"]
+    # **2026-08-13 修正**：本機的 results/ 是 git 版控目錄，本來就存在，
+    # 所有分析腳本（fit_real.py、inject_lowmass.py、profile_lowmass.py 等）
+    # 都直接假設它存在、從沒自己 mkdir。Kaggle 是全新環境，沒有人事先建這個
+    # 資料夾，於是計算跑完、最後 np.savez 存檔那一步才 FileNotFoundError——
+    # 實測 p9a_redo_v2 跑了 10.5 小時才在這裡炸掉，等於全部白算。統一在這裡
+    # 補一行建立 results/，不逐一修每支分析腳本（單點修正，以後新腳本也受益）。
+    copy_lines = ["os.makedirs('results', exist_ok=True)\n",
+                 f"shutil.copy('{base}{script}', '{script}')\n"]
     for f in extra_files:
         name = Path(f).name
         copy_lines.append(f"shutil.copy('{base}{name}', '{name}')\n")


### PR DESCRIPTION
## 問題
`p9a_redo_v2`（`fit_real.py`，config C，MH 鎖定檢驗）在 Kaggle 上跑了 10.5 小時後才失敗，log 顯示 `FileNotFoundError: '/kaggle/working/results/fit_real_fixmh_parsec_redo_v2.npz'`。

查證後發現 `fit_real.py`／`inject_lowmass.py`／`injection_recovery.py`／`measure_overconfidence.py`／`profile_lowmass.py`／`profile_outlierfrac.py` 全部直接對 `results/<name>.npz` 呼叫 `np.savez`，從沒自己 `mkdir`——本機因為 `results/` 是 git 版控目錄本來就存在，從沒踩到；Kaggle 是全新環境，`kaggle_sync.py` 打包時完全沒建立這個資料夾，所以每次都是**算完才在最後一步炸掉，等於白算**。

## 修法
在 `make_kernel()` 生成的 notebook 開頭統一加一行 `os.makedirs('results', exist_ok=True)`，單點修正，不逐一改每支分析腳本，以後新腳本自動受益。

## 驗證
用最小規模的 `fit_real.py` 測試（`n-syn 2000, repeats 1`）重跑，確認 `results/fit_real_resultsdir_fix_test.npz` 這次真的被存下來、kernel 狀態正常 `COMPLETE`。

## 已知代價
這次啟動的三項正式重跑（`p2_final2_v3`、`p9a_redo_v2`、`p9c_redo_v2`）用的都是修好前的舊 kernel 版本，`p9a_redo_v2` 已確認因這個 bug 錯誤（10.5 小時白算）；`p2_final2_v3`／`p9c_redo_v2` 這次修復推上去前就已經在跑，大機率也會在存檔那一步撞上同一個問題，需要在修好的程式碼上重新推送才能真的拿到結果。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **錯誤修正**
  * 執行 Kaggle 筆記本前會自動建立 `results/` 目錄，確保計算完成後能順利寫入結果檔案。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->