### PR TITLE
[Claude] fit_real.py 加 --repeat-offset，讓 --repeats 可以拆到多機器/帳號平行跑

### DIFF
--- a/fit_real.py
+++ b/fit_real.py
@@ -51,6 +51,13 @@ def main():
     # 「單次擬合的重現性」，A 與 C 的差要大於它才算真的位移。
     ap.add_argument("--repeats", type=int, default=1,
                     help="每個設定重複幾次（每次換一組模型端共用亂數）")
+    ap.add_argument("--repeat-offset", type=int, default=0,
+                    help="重複次數的起始索引偏移（種子 = 2000 + 13*(rep+offset)）。"
+                         "用來把同一組 --repeats N 拆到不同機器/帳號各跑一部分、"
+                         "彼此用不同亂數種子，例如 5 個帳號各跑 --repeats 2 "
+                         "搭配 --repeat-offset 0,2,4,6,8，結果檔案的 C 陣列"
+                         "沿 axis=0 串接起來就等於一次 --repeats 10 的結果。"
+                         "預設 0，不影響既有行為")
     ap.add_argument("--grid", default=GRID,
                     help="isochrone 網格檔名（在 isochrones/ 底下）。"
                          "換成 MIST 的檔案即可量出等時線模型造成的系統誤差")
@@ -186,9 +193,14 @@ def main():
             m.n_obs = len(color)
             m.selection = s
             m.bounds = base.bounds[:6].copy()
-            if args.repeats > 1:
-                m.draws = draw_randoms(m.n_syn,
-                                       np.random.default_rng(2000 + 13 * rep))
+            # repeat_offset 預設 0，只在明確要跨機器/帳號拆分時才會非零——
+            # 加進判斷式而不是只改種子公式，這樣 repeat_offset=0 時的行為
+            # 跟修改前逐位元相同（args.repeats==1 且沒給 offset 時完全不
+            # 重抽，沿用 base 建構時的預設種子），不影響任何既有結果。
+            if args.repeats > 1 or args.repeat_offset != 0:
+                m.draws = draw_randoms(
+                    m.n_syn,
+                    np.random.default_rng(2000 + 13 * (rep + args.repeat_offset)))
             if extra is not None:
                 m.enable_dav_fit(float(extra.min()), float(extra.max()))
             extra_axes = [extra] if extra is not None else []

--- a/fit_real.py
+++ b/fit_real.py
@@ -110,6 +110,8 @@ def main():
                     help="只用距星團中心 LO<=r<HI 度的成員擬合（例如 0,2）。"
                          "累積式用 0,r；環帶式用 lo,hi")
     args = ap.parse_args()
+    if args.repeat_offset < 0:
+        ap.error("--repeat-offset must be non-negative")
     refines = [int(x) for x in args.refines.split(",") if x.strip()]
     n_proc = args.procs or (os.cpu_count() or 1)
 


### PR DESCRIPTION
背景：headline `p2_final2_v3`（MH 自由 + 三階精修）在 Kaggle 上單次重複要 11.4 小時，10 次重複遠超 Kaggle 免費 session 上限（見 #50）。使用者要求評估「拆到多個 Kaggle 帳號各跑一部分、算完拼起來」是否可行。

## 做法
每次重複本來就用不同亂數種子（`2000 + 13*rep`）彼此獨立，但 `--repeats N` 永遠從 `rep=0` 算起，不同帳號各跑 `--repeats 1` 會全部用同一個種子、產生一模一樣的結果，沒有意義。加了 `--repeat-offset`（預設 0，不影響既有行為），讓不同機器/帳號可以用 `--repeats 1 --repeat-offset N` 跑到彼此不同的重複，結果檔案的 `C` 陣列事後沿 `axis=0` 串接就等於一次 `--repeats 10` 的結果。

## 驗證
小規模測試（`--n-syn 500 --repeats 1`）：`--repeat-offset 0` 與 `--repeat-offset 1` 給出明顯不同的 logage/A_V/alpha/MH/q_gamma/dav，證實 offset 真的改變了種子，不是兩邊都退回同一個預設值。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增 `--repeat-offset` 參數，可為重複擬合指定偏移索引。
  * 支援將多次重複擬合分散至不同機器執行，並使用不同的亂數種子。
* **改善**
  * 重複執行時的模型抽樣結果更具可重現性。
  * 單次執行且未指定偏移時，維持原有亂數行為。
  * 偏移索引不得為負值，輸入無效值時會顯示錯誤。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->