### PR TITLE
[Claude] 整理散落在根目錄的腳本，分類進 scripts/ 子資料夾

### DIFF
--- a/queue.txt
+++ b/queue.txt
@@ -19,7 +19,7 @@ item2b_repeat|fit_real.py --procs 8 --n-syn 40000 --repeats 5 --configs A,C --ta
 # 先下載官方打包檔（152 MB）並轉成與 PARSEC 同格式 ——
 # 欄位名一致，所以下游程式一行都不用改，「換等時線」才是唯一的變因。
 # 網頁表單那條路實測不通（會忽略 output_option=photometry、只回傳理論輸出）。
-item3a_mistgrid|build_mist_grid.py --logage-lo 7.80 --logage-hi 8.50 --mh-lo -0.50 --mh-hi 0.50
+item3a_mistgrid|scripts/data_prep/build_mist_grid.py --logage-lo 7.80 --logage-hi 8.50 --mh-lo -0.50 --mh-hi 0.50
 
 # 用 MIST 網格重跑同一批觀測。與 item2b 的差別只有等時線，
 # 兩者的 alpha 差就是「等時線模型」這一項的系統誤差 ——
@@ -31,7 +31,7 @@ item2c_repeat|fit_real.py --procs 8 --n-syn 40000 --repeats 5 --configs A,C --ta
 item3c_mistfit|fit_real.py --procs 8 --n-syn 40000 --repeats 5 --configs A,C --grid mist_v1.2_gaiaDR2_logt7.8-8.5_feh-0.5-0.5.dat --tag _mist
 
 # ===== P3a：下載 PARSEC 的 DR2 濾光片版（先跑，快，失敗要早知道）=====
-p3a_dr2grid|build_dr2_grid.py
+p3a_dr2grid|scripts/data_prep/build_dr2_grid.py
 
 # ===== P2：前向模型最終數字。C 設定 10 次，精修兩階（格距 0.022，
 # 避免 alpha 被量化到 2.1/2.3/2.5）。標準誤目標 ~0.03 =====
@@ -45,7 +45,7 @@ p6_lowmass|profile_lowmass.py --procs 8 --n-syn 40000 --repeats 3 --refines 3
 # p3a 重排：DR2 的 BP 有 bright/faint 兩套通帶，改取 faint 版（92% 樣本比 G=11 暗）
 # **必須排在 p3b 之前** —— p3b 要用它產生的重新命名網格檔。
 # 上一版順序寫反了，p3b 會先跑然後找不到檔案，這裡一併修掉。
-p3a2_dr2grid|build_dr2_grid.py
+p3a2_dr2grid|scripts/data_prep/build_dr2_grid.py
 
 # ===== P3b：用 DR2 濾光片的 PARSEC 重跑，與 EDR3 版相減 = 純濾光片效應 =====
 p3b_dr2fit|fit_real.py --procs 8 --n-syn 40000 --repeats 5 --configs A,C --grid parsec_v2.0_gaiaDR2_logt7.7-8.3s0.05_mh-0.6-0.6s0.05_renamed.dat --tag _dr2

--- a/scripts/data_prep/build_dr2_grid.py
+++ b/scripts/data_prep/build_dr2_grid.py
@@ -23,7 +23,7 @@ import shutil
 import sys
 from pathlib import Path
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 from pipeline import isochrones as iso  # noqa: E402

--- a/scripts/data_prep/build_mist_grid.py
+++ b/scripts/data_prep/build_mist_grid.py
@@ -10,7 +10,7 @@ import argparse
 import sys
 from pathlib import Path
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 from pipeline import mist  # noqa: E402

--- a/scripts/diagnostics/check_bright_outlier_kinematics.py
+++ b/scripts/diagnostics/check_bright_outlier_kinematics.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 TARGET_SOURCE_ID = 68409590552589184

--- a/scripts/diagnostics/check_c20_disagree_set.py
+++ b/scripts/diagnostics/check_c20_disagree_set.py
@@ -35,7 +35,7 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 

--- a/scripts/diagnostics/check_giant_subgiant_contamination.py
+++ b/scripts/diagnostics/check_giant_subgiant_contamination.py
@@ -36,7 +36,7 @@ from pathlib import Path
 
 import numpy as np
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 from pipeline.table_compat import Table  # noqa: E402

--- a/scripts/diagnostics/check_poisson_vs_multinomial.py
+++ b/scripts/diagnostics/check_poisson_vs_multinomial.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 import numpy as np
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 from pipeline.step3_age import hess  # noqa: E402 —— 故意真的 import，見下方 main()

--- a/scripts/diagnostics/check_rv_binary_fraction.py
+++ b/scripts/diagnostics/check_rv_binary_fraction.py
@@ -34,7 +34,7 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 G_SUN_AU3_MSUN_DAY2 = 2.959122e-4  # G in AU^3 / (Msun * day^2)

--- a/scripts/diagnostics/check_selection_color_residual.py
+++ b/scripts/diagnostics/check_selection_color_residual.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import numpy as np
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 sys.path.insert(0, str(HERE / "scripts" / "diagnostics"))
 

--- a/scripts/diagnostics/check_wd_exclusion_impact.py
+++ b/scripts/diagnostics/check_wd_exclusion_impact.py
@@ -47,7 +47,7 @@ from pathlib import Path
 import numpy as np
 from astropy.table import Table
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
 
 from pipeline import config as cfgmod, isochrones as isomod  # noqa: E402

--- a/scripts/diagnostics/check_white_dwarf_contamination.py
+++ b/scripts/diagnostics/check_white_dwarf_contamination.py
@@ -33,7 +33,7 @@ from pathlib import Path
 
 import numpy as np
 
-HERE = Path(__file__).resolve().parent
+HERE = Path(__file__).resolve().parent.parent.parent
 MEMBERS_CSV = HERE / "data" / "cmd_members.csv"
 VIZIER_CATALOG = "J/MNRAS/508/3877/maincat"
 


### PR DESCRIPTION
把還沒歸類的 10 支腳本搬進既有的 `scripts/` 分類，跟其他同性質的腳本放在一起：

- 8 支 `check_*.py` 一次性驗證腳本 -> `scripts/diagnostics/`
- `build_dr2_grid.py`、`build_mist_grid.py` -> `scripts/data_prep/`

每支腳本原本的 `HERE = Path(__file__).resolve().parent` 假設自己在 repo 根目錄（用來接 `data/`、`results/`），搬到 `scripts/<子資料夾>/` 後深了兩層，已同步改成 `.parent.parent.parent`（跟已經在 `scripts/` 底下的其他腳本同一種寫法）。`queue.txt` 裡三行引用 `build_mist_grid.py`/`build_dr2_grid.py` 的路徑也同步更新。

所有移動的腳本都用 `python -m py_compile` 驗證過。

## 刻意沒動的東西（避免打斷正在運作的正式流程，不是漏掉）

- `fit_real.py`、`inject_lowmass.py`、`injection_recovery.py`、`measure_overconfidence.py`、`profile_lowmass.py`、`profile_outlierfrac.py`：`queue.txt`/`kaggle_queue.txt` 大量以裸檔名引用，且目前正在做 Kaggle 派工復原，牽動面太廣
- `kaggle_*.py` 全家：自成一組現役基礎設施
- `run_queue.py`、`queue.txt`、`restart_queue_on_boot.ps1`：`restart_queue_on_boot.ps1` 用 `$PSScriptRoot` 算絕對路徑鎖定 `run_queue.py` 必須同目錄，這是 ARM64 機器上真實在跑的開機自動重啟排程（有真實事故紀錄：斷電重開機沒接上、浪費 8.5 小時算力），搬動風險遠大於整理收益
- 所有頂層 `*.md` 治理/追蹤文件：慣例上放 repo 根目錄讓每個 session 開始工作時第一眼就看到

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **錯誤修正**
  * 修正資料建置與診斷工具的路徑定位，確保可正確找到專案資料、結果與模組。
  * 更新佇列中的執行路徑，讓相關工作流程能正常啟動並維持原有參數設定。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->