### PR TITLE
fit_real.py/inject_lowmass.py 加 --repeat-offset/--trial-offset（重新套用 PR #55）

### DIFF
--- a/fit_real.py
+++ b/fit_real.py
@@ -151,6 +151,13 @@ def main():
     # 「單次擬合的重現性」，A 與 C 的差要大於它才算真的位移。
     ap.add_argument("--repeats", type=int, default=1,
                     help="每個設定重複幾次（每次換一組模型端共用亂數）")
+    ap.add_argument("--repeat-offset", type=int, default=0,
+                    help="重複次數的起始索引偏移（種子 = 2000 + 13*(rep+offset)）。"
+                         "用來把同一組 --repeats N 拆到不同機器/帳號各跑一部分、"
+                         "彼此用不同亂數種子，例如 5 個帳號各跑 --repeats 1 "
+                         "搭配 --repeat-offset 0,1,2,3,4，結果檔案的 C 陣列"
+                         "沿 axis=0 串接起來就等於一次 --repeats 5 的結果。"
+                         "預設 0，不影響既有行為（見 PR #55）")
     ap.add_argument("--grid", default=GRID,
                     help="isochrone 網格檔名（在 isochrones/ 底下）。"
                          "換成 MIST 的檔案即可量出等時線模型造成的系統誤差")
@@ -203,6 +210,8 @@ def main():
                     help="只用距星團中心 LO<=r<HI 度的成員擬合（例如 0,2）。"
                          "累積式用 0,r；環帶式用 lo,hi")
     args = ap.parse_args()
+    if args.repeat_offset < 0:
+        ap.error("--repeat-offset must be non-negative")
     refines = [int(x) for x in args.refines.split(",") if x.strip()]
     n_proc = args.procs or (os.cpu_count() or 1)
 
@@ -324,8 +333,9 @@ def main():
             # `--repeats 10` 的工作拆成多次獨立呼叫（例如分散到不同機器），
             # 結果跟一次跑完完全等價，也是這次能續傳的前提（續傳本質上
             # 就是「用同一個索引重跑一次」，種子不能因為 repeats 不同而變）。
-            m.draws = draw_randoms(m.n_syn,
-                                   np.random.default_rng(2000 + 13 * rep))
+            m.draws = draw_randoms(
+                m.n_syn,
+                np.random.default_rng(2000 + 13 * (rep + args.repeat_offset)))
             if extra is not None:
                 m.enable_dav_fit(float(extra.min()), float(extra.max()))
             extra_axes = [extra] if extra is not None else []

--- a/fit_real.py
+++ b/fit_real.py
@@ -52,7 +52,22 @@ def build_manifest(args) -> dict:
         "free_lowmass": args.free_lowmass,
         "native_bprp_err": args.native_bprp_err,
         "radius_range": args.radius_range,
+        # 2026-08-19 CodeRabbit PR #62 抓到：--repeat-offset 會改動每次重複的
+        # 亂數種子，所以它跟 --n-syn 一樣是「會改變結果」的輸入。少了它，同一個
+        # --tag 先用 offset 0 寫入部分結果、再用 offset 1 續跑時 manifest 完全
+        # 相同，rep < len(reps) 會直接跳過重算，把 offset 0 的結果當成 offset 1
+        # 的結果沿用。
+        "repeat_offset": args.repeat_offset,
     }
+
+
+# 舊檔案的 manifest 可能缺少後來才加進來的鍵。缺鍵不等於「設定不同」——
+# 那個旗標當時根本不存在，所以舊檔案必定是用該旗標的預設值算出來的。
+# 這裡明確寫出每個後加鍵的「當時等效值」，讓缺鍵的舊檔案只在這次真的用了
+# 非預設值時才判為不相容，不會因為補了一個欄位就逼所有既有部分結果重算。
+MANIFEST_LEGACY_DEFAULTS = {
+    "repeat_offset": 0,
+}
 
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
@@ -153,10 +168,14 @@ def main():
                     help="每個設定重複幾次（每次換一組模型端共用亂數）")
     ap.add_argument("--repeat-offset", type=int, default=0,
                     help="重複次數的起始索引偏移（種子 = 2000 + 13*(rep+offset)）。"
-                         "用來把同一組 --repeats N 拆到不同機器/帳號各跑一部分、"
-                         "彼此用不同亂數種子，例如 5 個帳號各跑 --repeats 1 "
-                         "搭配 --repeat-offset 0,1,2,3,4，結果檔案的 C 陣列"
-                         "沿 axis=0 串接起來就等於一次 --repeats 5 的結果。"
+                         "只吃單一整數，不接受逗號清單。用來把同一組 --repeats N "
+                         "拆到不同機器/帳號各跑一部分、彼此用不同亂數種子：5 個帳號"
+                         "各跑一次時，是各自下 --repeats 1 --repeat-offset 0 / 1 / "
+                         "2 / 3 / 4 五道獨立指令。**每個分片必須配一個唯一的 --tag**"
+                         "（例如 _p2final_v3_rep0 ... _rep4）——輸出路徑只由 --tag "
+                         "決定，共用同一個 --tag 的分片會互相覆寫，atomic_savez() "
+                         "不會幫忙合併。全部跑完後把各檔案的 C 陣列依 offset 由小到大"
+                         "沿 axis=0 串接，即等於一次 --repeats 5 的結果。"
                          "預設 0，不影響既有行為（見 PR #55）")
     ap.add_argument("--grid", default=GRID,
                     help="isochrone 網格檔名（在 isochrones/ 底下）。"
@@ -294,8 +313,12 @@ def main():
                   flush=True)
         else:
             old_manifest = json.loads(str(old_manifest_arr))
-            diffs = {k: (old_manifest.get(k), v) for k, v in manifest.items()
-                     if old_manifest.get(k) != v}
+
+            def _old(k):
+                return old_manifest.get(k, MANIFEST_LEGACY_DEFAULTS.get(k))
+
+            diffs = {k: (_old(k), v) for k, v in manifest.items()
+                     if _old(k) != v}
             if diffs:
                 print(f"錯誤：{out_path.name} 已有部分結果，但執行設定跟"
                       f"這次不同（{diffs}）。沿用會把兩種不可比的設定混進"

--- a/inject_lowmass.py
+++ b/inject_lowmass.py
@@ -76,10 +76,14 @@ def main():
     ap.add_argument("--trials", type=int, default=2)
     ap.add_argument("--trial-offset", type=int, default=0,
                     help="試驗次數的起始索引偏移（假資料種子 = 7000+37*(t+offset)，"
-                         "擬合種子 = 4000+11*(t+offset)）。用來把同一組 --trials N "
-                         "拆到不同機器/帳號各跑一部分（例如 3 個帳號各跑 --trials 1 "
-                         "搭配 --trial-offset 0,1,2），結果沿 axis=0 串接即等於一次"
-                         "跑完。預設 0，不影響既有行為（比照 fit_real.py 的"
+                         "擬合種子 = 4000+11*(t+offset)）。只吃單一整數，不接受逗號"
+                         "清單。用來把同一組 --trials N 拆到不同機器/帳號各跑一部分："
+                         "3 個帳號各跑一次時，是各自下 --trials 1 --trial-offset 0 / "
+                         "1 / 2 三道獨立指令。**每個分片必須配一個唯一的 --tag**"
+                         "（例如 _p6b_v2_t0 / _t1 / _t2）——輸出路徑只由 --tag 決定，"
+                         "共用同一個 --tag 的分片會互相覆寫，atomic_savez() 不會幫忙"
+                         "合併。全部跑完後把各檔案依 offset 由小到大沿 axis=0 串接，"
+                         "即等於一次跑完。預設 0，不影響既有行為（比照 fit_real.py 的"
                          "--repeat-offset，見 PR #55）")
     ap.add_argument("--refines", default="3")
     ap.add_argument("--dav-max", type=float, default=0.6)

--- a/inject_lowmass.py
+++ b/inject_lowmass.py
@@ -74,6 +74,13 @@ def main():
     ap.add_argument("--procs", type=int, default=None)
     ap.add_argument("--n-syn", type=int, default=40000)
     ap.add_argument("--trials", type=int, default=2)
+    ap.add_argument("--trial-offset", type=int, default=0,
+                    help="試驗次數的起始索引偏移（假資料種子 = 7000+37*(t+offset)，"
+                         "擬合種子 = 4000+11*(t+offset)）。用來把同一組 --trials N "
+                         "拆到不同機器/帳號各跑一部分（例如 3 個帳號各跑 --trials 1 "
+                         "搭配 --trial-offset 0,1,2），結果沿 axis=0 串接即等於一次"
+                         "跑完。預設 0，不影響既有行為（比照 fit_real.py 的"
+                         "--repeat-offset，見 PR #55）")
     ap.add_argument("--refines", default="3")
     ap.add_argument("--dav-max", type=float, default=0.6)
     ap.add_argument("--tag", default="", help="輸出檔名後綴，避免覆蓋前一次跑的"
@@ -84,6 +91,8 @@ def main():
                          "不是全部三個都跑。用於補測單一可疑結果，不用重跑"
                          "整批（見 LIMITATIONS.md D5）")
     args = ap.parse_args()
+    if args.trial_offset < 0:
+        ap.error("--trial-offset must be non-negative")
     p_true_list = P_TRUE_LIST
     if args.only is not None:
         if args.only not in P_TRUE_LIST:
@@ -155,7 +164,8 @@ def main():
             gen = base.with_observations(color, mag)
             gen.selection = sel
             gen.low_mass_slope = -p_true
-            fc, fm = make_fake(gen, THETA_TRUE, n_obs, seed=7000 + 37 * t,
+            fc, fm = make_fake(gen, THETA_TRUE, n_obs,
+                               seed=7000 + 37 * (t + args.trial_offset),
                                dav=dav_true, selection=sel)
 
             # 擬合：八參數，低質量段冪次自由
@@ -164,8 +174,9 @@ def main():
             m.bounds = base.bounds[:6].copy()
             m.enable_dav_fit(0.0, args.dav_max)
             m.enable_lowmass_fit(P_MIN, P_MAX)
-            m.draws = draw_randoms(m.n_syn,
-                                   np.random.default_rng(4000 + 11 * t))
+            m.draws = draw_randoms(
+                m.n_syn,
+                np.random.default_rng(4000 + 11 * (t + args.trial_offset)))
             t0 = time.time()
             # q_gamma(5) 與 dav(6) 是已知的 nuisance，貼牆放行；
             # p_lowmass(7) **不放行** —— 它貼牆正是我們要偵測的失敗模式。


### PR DESCRIPTION
重新套用 --repeat-offset（取代 PR #55——那個分支基於舊版 main，直接合併會蓋掉後來加的續傳/鎖檔/manifest 驗證功能，改成只把核心的種子偏移邏輯套用到目前 main 版本上），並比照加了 `inject_lowmass.py` 的 `--trial-offset`。

## 動機
- headline `p2_final2_v3` 還差 5 次重複（`--repeat-offset 5,6,7,8,9`）才能合併成最終數字，需要這個旗標才能繼續派工。
- `p6b_inject_lowmass_v2` 在 Kaggle 上一直失敗（`--trials 3` 三個 trial 加起來超過 12 小時 cell 上限，只完成 2/3 就被砍），加 `--trial-offset` 之後可以拆成 3 個 `--trials 1` kernel 平行跑。

## 改動
- `fit_real.py`：`--repeat-offset`（種子 = `2000 + 13*(rep+offset)`），預設 0 不影響既有行為。
- `inject_lowmass.py`：`--trial-offset`（假資料種子 = `7000+37*(t+offset)`，擬合種子 = `4000+11*(t+offset)`），預設 0 不影響既有行為。

PR #55 可以關掉，功能已經在這裡用不衝突的方式重做。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 `--repeat-offset` 參數，可將重複執行分散至不同環境，並維持各次執行的亂數種子一致性。
  * 新增 `--trial-offset` 參數，支援分批執行試驗，同時保持假資料與模型擬合結果可重現。
  * 偏移值不接受負數；未指定時維持原有行為。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->