### PR TITLE
kaggle_queue.py 加單例鎖 + 開機自動重啟涵蓋兩條佇列

### DIFF
--- a/kaggle_queue.py
+++ b/kaggle_queue.py
@@ -35,6 +35,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import time
@@ -42,10 +43,12 @@ from datetime import datetime
 from pathlib import Path
 
 import kaggle_accounts
+from run_queue import _pid_alive  # 單例鎖用，見 acquire_lock() 的說明
 
 HERE = Path(__file__).resolve().parent
 QUEUE = HERE / "kaggle_queue.txt"
 DONE = HERE / "logs" / "kaggle_queue_done.txt"
+LOCK = HERE / "logs" / "kaggle_queue.lock"
 POLL_SECS = 60
 # 免費 CPU notebook 的執行時間上限一般約 9-12 小時，留一點餘裕就中止輪詢
 # （不強制砍 kernel，只是本地停止等待，之後可以再手動 pull）。
@@ -53,6 +56,57 @@ MAX_WAIT_HOURS = 11
 # dataset 掛載時序不穩，偵測到那個特定失敗模式就重推 kernel，
 # 間隔遞增（不是猜一個固定等待時長，見 is_mount_race_failure 的說明）。
 BACKOFFS = [60, 120, 240, 480]
+
+
+def acquire_lock():
+    """單例鎖，避免兩個 kaggle_queue.py 同時搶佇列——跟 run_queue.py 的
+    acquire_lock() 同一個理由、同一套寫法（O_CREAT|O_EXCL 原子建立，PID
+    存活探測失敗一律 fail closed）：2026-08-18 這台機器重開機後，
+    restart_queue_on_boot.ps1 的行程比對（比對啟動指令列裡的絕對路徑）
+    因為手動用相對路徑啟動過一次而漏配，誤判成「沒在跑」又重啟了一份，
+    兩個 kaggle_queue.py 同時活著（只是還沒真的撞在一起做出壞事就先發現
+    並砍掉了）。當時 run_queue.py 自己因為有這個鎖而安全退出，
+    kaggle_queue.py 沒有，這裡補上，讓保護不再只靠 PowerShell 那邊的
+    快速路徑檢查。"""
+    LOCK.parent.mkdir(exist_ok=True)
+    while True:
+        try:
+            fd = os.open(str(LOCK), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+        except FileExistsError:
+            try:
+                old_pid = int(LOCK.read_text().strip())
+            except (ValueError, OSError):
+                old_pid = None
+            alive = _pid_alive(old_pid) if old_pid is not None else False
+            if alive is None:
+                print(f"無法確認鎖檔案（PID {old_pid}）是否還存活"
+                      f"（tasklist 探測失敗），保守起見當作還活著，"
+                      f"退出，不搶佇列。", flush=True)
+                sys.exit(1)
+            if alive:
+                print(f"偵測到另一個 kaggle_queue.py 正在跑（PID {old_pid}），"
+                      f"退出，不搶佇列。", flush=True)
+                sys.exit(1)
+            print(f"鎖檔案殘留（PID {old_pid} 已不存在，視為上次沒清"
+                  f"乾淨），清掉重新搶鎖。", flush=True)
+            try:
+                LOCK.unlink()
+            except FileNotFoundError:
+                pass
+            continue
+        else:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(str(os.getpid()))
+            return
+
+
+def release_lock():
+    """只在鎖確實是自己持有時才刪除——避免刪掉別人剛搶到的鎖。"""
+    try:
+        if int(LOCK.read_text().strip()) == os.getpid():
+            LOCK.unlink()
+    except (FileNotFoundError, ValueError, OSError):
+        pass
 
 
 def read_queue() -> list[dict]:
@@ -159,6 +213,37 @@ def is_mount_race_failure(label: str) -> bool:
     return False
 
 
+def recover_running_slots(accounts: dict, envs: dict) -> dict[str, dict | None]:
+    """開機時的復原：掃描所有還沒標記完成的待辦項目，看有沒有帳號已經在
+    Kaggle 端跑著對應的 kernel（2026-08-18 這台機器連續遇到兩次非預期
+    重開機——本機重開機／agent session 中斷不會影響 Kaggle 端已經在跑的
+    kernel，只會讓這支輪詢器失去追蹤；重開這支腳本若直接對每個閒置帳號
+    重推，等於中斷已經跑了一段時間的進度，白算掉）。找到 RUNNING／QUEUED
+    的就接回槽位，不重推；找不到才照原本流程當作全新工作處理。"""
+    done = read_done()
+    pending = [it for it in read_queue() if it["label"] not in done]
+    slots: dict[str, dict | None] = {name: None for name in accounts}
+    for name in accounts:
+        for item in pending:
+            if item["account"] not in (None, name):
+                continue
+            slug = item["label"].replace("_", "-")
+            username = accounts[name]["username"]
+            kid = f"{username}/m45-imf-run-{slug}"
+            r = run(["kaggle", "kernels", "status", kid], env=envs[name])
+            status = (r.stdout + r.stderr).strip()
+            if "RUNNING" in status or "QUEUED" in status:
+                slots[name] = {
+                    "phase": "running", "item": item, "kid": kid,
+                    "work_dir": HERE / "kaggle_work" / name,
+                    "t0": time.time(), "retries": 0,
+                }
+                print(f"復原：{name} 已經在跑 {item['label']}（{kid}），"
+                      f"接回追蹤、不重推", flush=True)
+                break
+    return slots
+
+
 def push_kernel_only(work_dir: Path, env: dict) -> bool:
     """只重推 kernel，沿用該帳號 work_dir 裡已經上傳過的 dataset。"""
     r = run(["kaggle", "kernels", "push", "-p", str(work_dir)], env=env)
@@ -175,14 +260,24 @@ def pull(kid: str, label: str, env: dict) -> None:
 
 
 def main() -> None:
+    acquire_lock()
+    import atexit
+    atexit.register(release_lock)  # 涵蓋正常結束、例外、sys.exit()
+
     accounts = kaggle_accounts.load_accounts()
     print(f"Kaggle 佇列執行器啟動 {datetime.now():%Y-%m-%d %H:%M:%S}，"
           f"{len(accounts)} 個帳號同時派工：{list(accounts)}", flush=True)
     envs = {name: kaggle_accounts.env_for(info)
             for name, info in accounts.items()}
 
-    # slots[帳號名] = None（閒置）或一個描述目前工作狀態的 dict
-    slots: dict[str, dict | None] = {name: None for name in accounts}
+    # slots[帳號名] = None（閒置）或一個描述目前工作狀態的 dict。
+    # 啟動時先掃一輪，接回任何帳號已經在 Kaggle 端跑著的 kernel，
+    # 不要無條件當成全新一輪、把還在跑的進度重推掉。
+    slots = recover_running_slots(accounts, envs)
+    if any(slots.values()):
+        running = [n for n, s in slots.items() if s]
+        print(f"復原完成，接回 {len(running)} 個已在跑的槽位：{running}",
+              flush=True)
 
     while True:
         done = read_done()

--- a/kaggle_queue.py
+++ b/kaggle_queue.py
@@ -181,18 +181,53 @@ def push(item: dict, account_name: str) -> tuple[bool, str, Path]:
     return r.returncode == 0, kid, work_dir
 
 
-def check_status_once(kid: str, env: dict) -> str | None:
-    """查一次狀態，不阻塞等待。回傳 "ok"/"error"/"cancelled"（終止狀態）
-    或 None（還在排隊或執行中，下一輪再查）。
+# probe_kernel_status() 的回傳值裡代表「kernel 真的跑完了」的那幾個。
+TERMINAL = {"complete", "error", "cancelled"}
+
+
+def probe_kernel_status(kid: str, env: dict) -> str:
+    """查一次 kernel 狀態，把「還在跑」「不存在」「查不到」三種情況分開。
+
+    2026-08-19 CodeRabbit PR #66 指出：原本 check_status_once() 對這三種
+    情況一律回傳 None，呼叫端只能一律當成「還在跑，下一輪再看」。在主迴圈
+    裡那是安全的，但在 recover_running_slots() 裡不是——「不存在」要讓槽位
+    空著去派新工作，「查不到」（網路斷、憑證過期、被限流）則絕對不能，那會
+    讓復原邏輯誤判成沒人在跑而重推，把遠端已經跑了十幾小時的進度洗掉。
+
+    實測 `kaggle kernels status` 的輸出（2026-08-19）：
+      存在   -> returncode 0，stdout 有 `has status "KernelWorkerStatus.XXX"`
+      不存在 -> returncode 1，stderr 是 `Cannot access kernel ...`
+                （訊息自稱是權限問題，但實際上打錯 slug 也是這一句）
+    其他非零退出碼一律歸到 "unknown"，由呼叫端決定要不要保守處理。
+
+    回傳 "running"／"complete"／"error"／"cancelled"／"missing"／"unknown"。
     """
     r = run(["kaggle", "kernels", "status", kid], env=env)
-    status = (r.stdout + r.stderr).strip()
-    if "COMPLETE" in status:
+    text = (r.stdout + r.stderr).strip()
+    if r.returncode == 0 and "has status" in text:
+        if "COMPLETE" in text:
+            return "complete"
+        if "ERROR" in text:
+            return "error"
+        if "CANCEL" in text:
+            return "cancelled"
+        return "running"        # RUNNING／QUEUED 等尚未結束的狀態
+    if "Cannot access kernel" in text or "wrong kernel slug" in text:
+        return "missing"
+    print(f"  查詢 {kid} 狀態失敗（rc={r.returncode}）：{text[:300]}",
+          flush=True)
+    return "unknown"
+
+
+def check_status_once(kid: str, env: dict) -> str | None:
+    """查一次狀態，不阻塞等待。回傳 "ok"/"error"/"cancelled"（終止狀態）
+    或 None（還在排隊或執行中，或這次查不到——都是「先不要下結論」）。
+    """
+    st = probe_kernel_status(kid, env)
+    if st == "complete":
         return "ok"
-    if "ERROR" in status:
-        return "error"
-    if "CANCEL" in status:
-        return "cancelled"
+    if st in ("error", "cancelled"):
+        return st
     return None
 
 
@@ -225,7 +260,19 @@ def recover_running_slots(accounts: dict, envs: dict) -> dict[str, dict | None]:
     重開機——本機重開機／agent session 中斷不會影響 Kaggle 端已經在跑的
     kernel，只會讓這支輪詢器失去追蹤；重開這支腳本若直接對每個閒置帳號
     重推，等於中斷已經跑了一段時間的進度，白算掉）。找到 RUNNING／QUEUED
-    的就接回槽位，不重推；找不到才照原本流程當作全新工作處理。"""
+    的就接回槽位，不重推；找不到才照原本流程當作全新工作處理。
+
+    2026-08-19 CodeRabbit PR #66 補了兩個原本會漏掉的情況：
+      * **遠端已經跑完**（COMPLETE／ERROR／CANCELLED）：本機失聯期間 kernel
+        自己結束了。原本只認 RUNNING／QUEUED，會留下空槽位，主迴圈接著把
+        同一個 label 重推一次——COMPLETE 的話等於把已經算完的結果丟掉重算。
+        改成 COMPLETE 就照正常流程 pull + mark_done；ERROR／CANCELLED
+        **不標 done**，讓主迴圈照既有的重推/重試邏輯處理（那是這支腳本本來
+        就有的失敗處置，不該在復原路徑另立一套）。
+      * **狀態查不到**（網路斷、憑證過期、被限流）：這跟「kernel 不存在」
+        看起來都像沒東西在跑，但處置相反。查不到時**佔住槽位**這一輪不派
+        新工作，下一輪再查；寧可慢一輪，也不要在遠端其實正在跑的情況下重推。
+    """
     done = read_done()
     pending = [it for it in read_queue() if it["label"] not in done]
     slots: dict[str, dict | None] = {name: None for name in accounts}
@@ -236,9 +283,23 @@ def recover_running_slots(accounts: dict, envs: dict) -> dict[str, dict | None]:
             slug = item["label"].replace("_", "-")
             username = accounts[name]["username"]
             kid = f"{username}/m45-imf-run-{slug}"
-            r = run(["kaggle", "kernels", "status", kid], env=envs[name])
-            status = (r.stdout + r.stderr).strip()
-            if "RUNNING" in status or "QUEUED" in status:
+            st = probe_kernel_status(kid, envs[name])
+            if st == "missing":
+                continue        # 這個帳號沒推過這項，繼續看下一項
+            if st == "unknown":
+                # 查不到就保守處理：佔住槽位、這一輪不派新工作。
+                # phase="probe" 不帶 kid，主迴圈的忙碌槽位檢查會跳過它，
+                # 下一輪復原式查詢由 main() 的 requeue 邏輯重來。
+                slots[name] = {
+                    "phase": "probe", "item": item, "kid": kid,
+                    "work_dir": HERE / "kaggle_work" / name,
+                    "t0": time.time(), "retries": 0,
+                }
+                print(f"復原：{name} 查 {item['label']}（{kid}）狀態失敗，"
+                      f"這一輪不派新工作，下一輪再查（避免遠端其實正在跑"
+                      f"卻被重推洗掉）", flush=True)
+                break
+            if st == "running":
                 slots[name] = {
                     "phase": "running", "item": item, "kid": kid,
                     "work_dir": HERE / "kaggle_work" / name,
@@ -247,6 +308,19 @@ def recover_running_slots(accounts: dict, envs: dict) -> dict[str, dict | None]:
                 print(f"復原：{name} 已經在跑 {item['label']}（{kid}），"
                       f"接回追蹤、不重推", flush=True)
                 break
+            if st == "complete":
+                print(f"復原：{name} 的 {item['label']}（{kid}）在本機失聯"
+                      f"期間已經 COMPLETE，補拉結果並標記完成，不重算",
+                      flush=True)
+                if pull(kid, item["label"], envs[name]):
+                    mark_done(item["label"], "ok", 0, name)
+                else:
+                    print(f"  結果下載失敗，不標記完成——留給主迴圈重試",
+                          flush=True)
+                continue        # 槽位保持空著，可以接新工作
+            # error／cancelled：不標 done，讓主迴圈照既有失敗處置重推
+            print(f"復原：{name} 的 {item['label']}（{kid}）遠端狀態為 "
+                  f"{st}，交回主迴圈照既有重試流程處理", flush=True)
     return slots
 
 
@@ -259,10 +333,23 @@ def push_kernel_only(work_dir: Path, env: dict) -> bool:
     return r.returncode == 0
 
 
-def pull(kid: str, label: str, env: dict) -> None:
+def pull(kid: str, label: str, env: dict) -> bool:
+    """下載 kernel 輸出。回傳是否成功。
+
+    2026-08-19 CodeRabbit PR #66 指出：原本丟掉 `kaggle kernels output` 的
+    回傳碼，呼叫端無論下載成功與否都接著 mark_done()——DONE 檔一寫下去就
+    不會再重試，等於一次網路中斷就永久丟掉一個已經算完的 kernel 的結果。
+    這在這個專案不是假設性風險：rep5 的下載就曾經因為 IncompleteRead 中斷
+    過，當時是人工發現才補拉的。
+    """
     out = HERE / "kaggle_results" / label
     out.mkdir(parents=True, exist_ok=True)
-    run(["kaggle", "kernels", "output", kid, "-p", str(out)], env=env)
+    r = run(["kaggle", "kernels", "output", kid, "-p", str(out)], env=env)
+    if r.returncode != 0:
+        print(f"  下載 {kid} 輸出失敗（rc={r.returncode}）："
+              f"{(r.stderr or r.stdout)[-500:]}", flush=True)
+        return False
+    return True
 
 
 def main() -> None:
@@ -316,6 +403,38 @@ def main() -> None:
         for name, slot in list(slots.items()):
             if slot is None:
                 continue
+            if slot["phase"] == "probe":
+                # 復原時狀態查不到而暫時佔住的槽位（見 recover_running_slots）。
+                # 每一輪重查一次，查得到就照結果轉正常流程；還是查不到就繼續
+                # 佔著——「查不到」代表我們無從判斷遠端到底有沒有在跑，這種
+                # 情況下派新工作的風險（重推洗掉進度）遠大於慢一輪的代價。
+                # 持續查不到通常是憑證過期或網路斷，屬於要人介入的狀況，
+                # 每一輪都印出來讓它顯眼。
+                st = probe_kernel_status(slot["kid"], envs[name])
+                if st == "missing":
+                    print(f"  [{name}] {slot['item']['label']} 確認遠端沒有這個"
+                          f"kernel，釋放槽位、照正常流程派工", flush=True)
+                    slots[name] = None
+                elif st == "running":
+                    slot["phase"] = "running"
+                    slot["t0"] = time.time()
+                    print(f"  [{name}] {slot['item']['label']} 查到遠端正在跑，"
+                          f"接回追蹤", flush=True)
+                elif st in TERMINAL:
+                    if st == "complete":
+                        if pull(slot["kid"], slot["item"]["label"], envs[name]):
+                            mark_done(slot["item"]["label"], "ok", 0, name)
+                        else:
+                            print(f"  [{name}] 結果下載失敗，保留工作供下一輪"
+                                  f"重試", flush=True)
+                            continue
+                    slots[name] = None
+                else:
+                    print(f"  [{name}] {slot['item']['label']} 狀態仍查不到，"
+                          f"繼續佔住槽位（若持續如此請檢查憑證與網路）",
+                          flush=True)
+                continue
+
             if slot["phase"] == "cooldown":
                 if time.time() >= slot["resume_at"]:
                     ok = push_kernel_only(slot["work_dir"], envs[name])
@@ -337,7 +456,16 @@ def main() -> None:
                 # 就照正常流程 pull，不要平白丟掉可能剛好算完的結果。
                 final_status = check_status_once(slot["kid"], envs[name])
                 if final_status is not None:
-                    pull(slot["kid"], slot["item"]["label"], envs[name])
+                    pulled = pull(slot["kid"], slot["item"]["label"],
+                                  envs[name])
+                    if final_status == "ok" and not pulled:
+                        # 已經 COMPLETE 卻拉不下來：**絕對不能 mark_done**，
+                        # 那會讓這個算完的 kernel 永遠不再被重試。留在槽位裡
+                        # 下一輪重拉（逾時判斷會再次成立，所以是每輪重試一次）。
+                        print(f"[{datetime.now():%H:%M:%S}] [{name}] "
+                              f"{slot['item']['label']} 已 COMPLETE 但結果"
+                              f"下載失敗，保留工作供下一輪重試", flush=True)
+                        continue
                     mark_done(slot["item"]["label"], final_status,
                              time.time() - slot["t0"], name)
                     print(f"[{datetime.now():%H:%M:%S}] [{name}] "
@@ -353,7 +481,14 @@ def main() -> None:
             if status is None:
                 continue    # 還在跑，下一輪再看
 
-            pull(slot["kid"], slot["item"]["label"], envs[name])
+            pulled = pull(slot["kid"], slot["item"]["label"], envs[name])
+            if status == "ok" and not pulled:
+                # 同上：算完了但結果沒拉下來，不標記完成，下一輪重拉。
+                # 只對 "ok" 這樣做——"error"／"cancelled" 拉的是 log 不是
+                # 結果，拉不到不該讓槽位卡住不放。
+                print(f"  [{name}] {slot['item']['label']} 已 COMPLETE 但"
+                      f"結果下載失敗，保留工作供下一輪重試", flush=True)
+                continue
             if (status == "error" and is_mount_race_failure(slot["item"]["label"])
                     and slot["retries"] < len(BACKOFFS)):
                 wait_s = BACKOFFS[slot["retries"]]

--- a/kaggle_queue.py
+++ b/kaggle_queue.py
@@ -50,9 +50,15 @@ QUEUE = HERE / "kaggle_queue.txt"
 DONE = HERE / "logs" / "kaggle_queue_done.txt"
 LOCK = HERE / "logs" / "kaggle_queue.lock"
 POLL_SECS = 60
-# 免費 CPU notebook 的執行時間上限一般約 9-12 小時，留一點餘裕就中止輪詢
-# （不強制砍 kernel，只是本地停止等待，之後可以再手動 pull）。
-MAX_WAIT_HOURS = 11
+# 免費 CPU notebook 的執行時間上限文件說約 9-12 小時，但 2026-08-19 實測
+# --refines 3,3,3 的 headline recipe 單次重複跑了 62544-62604 秒
+# （~17.4 小時）才 COMPLETE——原本設 11 小時太保守，導致本機輪詢器在
+# kernel 快完成前就放棄，差點漏接 4 個已經算完的結果（靠人工事後查證
+# 才補救回來，見 check_status_once() 呼叫處的說明）。調高到 20 小時，
+# 並且逾時放棄前一律最後補查一次狀態、COMPLETE 就照樣 pull，兩道防線
+# 一起降低漏接風險（不強制砍 kernel，只是本地停止等待，逾時後仍可以
+# 再手動 pull）。
+MAX_WAIT_HOURS = 20
 # dataset 掛載時序不穩，偵測到那個特定失敗模式就重推 kernel，
 # 間隔遞增（不是猜一個固定等待時長，見 is_mount_race_failure 的說明）。
 BACKOFFS = [60, 120, 240, 480]
@@ -323,8 +329,23 @@ def main() -> None:
 
             elapsed_h = (time.time() - slot["t0"]) / 3600
             if elapsed_h > MAX_WAIT_HOURS:
-                mark_done(slot["item"]["label"], "timeout",
-                         time.time() - slot["t0"], name)
+                # 2026-08-19 教訓：這個 recipe（--refines 3,3,3）單次重複
+                # 實測跑了 62544-62604 秒（~17.4 小時）才真的 COMPLETE，
+                # 遠超 MAX_WAIT_HOURS=11——本機輪詢器直接放棄不拉結果，
+                # 差點漏接 4 個已經算完的 kernel（rep5-8），只是剛好人工
+                # 事後查證才發現。逾時放棄前，最後再查一次狀態，COMPLETE
+                # 就照正常流程 pull，不要平白丟掉可能剛好算完的結果。
+                final_status = check_status_once(slot["kid"], envs[name])
+                if final_status is not None:
+                    pull(slot["kid"], slot["item"]["label"], envs[name])
+                    mark_done(slot["item"]["label"], final_status,
+                             time.time() - slot["t0"], name)
+                    print(f"[{datetime.now():%H:%M:%S}] [{name}] "
+                          f"{slot['item']['label']} 逾時前最後一查，其實已經"
+                          f"結束：{final_status}，已補拉結果", flush=True)
+                else:
+                    mark_done(slot["item"]["label"], "timeout",
+                             time.time() - slot["t0"], name)
                 slots[name] = None
                 continue
 

--- a/restart_queue_on_boot.ps1
+++ b/restart_queue_on_boot.ps1
@@ -43,10 +43,16 @@
 #    「失敗路徑可能被靜默吞掉」風險的活生生案例，所以這次補上
 #    -ErrorAction Stop + exit 1，讓失敗至少能被工作排程器看到。
 
+# **2026-08-18 擴充，同一支腳本一併顧 kaggle_queue.py**：這台機器（Acer
+# AI 16）連續遇到兩次非預期重開機（8/16、8/18），第二次連 kaggle_queue.py
+# 這支輪詢器也一起被砍了——雖然 Kaggle 端的 kernel 不受影響（本機重開機
+# 砍不到遠端），但本機沒有輪詢器就沒人去 pull 結果、也沒人往下派剩下的
+# 待辦項目。kaggle_queue.py 已經加了 recover_running_slots()（開機時
+# 掃描接回已在跑的 kernel，不會重推打斷進度），重啟這支跟重啟
+# run_queue.py 一樣安全，一併加進來顧。
+
 $repo = $PSScriptRoot
 $selfLog = Join-Path $repo "logs\autorestart.log"
-$queueLog = Join-Path $repo "logs\queue_runner8.log"
-$scriptPath = Join-Path $repo "run_queue.py"
 
 function Write-SelfLog {
     param([string]$Message)
@@ -59,33 +65,44 @@ function Write-SelfLog {
     }
 }
 
+function Restart-QueueIfNotRunning {
+    param(
+        [string]$ScriptName,   # 例如 "run_queue.py"
+        [string]$LogFile       # 對應的輸出 log 檔名
+    )
+    $scriptPath = Join-Path $repo $ScriptName
+    $queueLog = Join-Path $repo "logs\$LogFile"
+
+    # 只比對這個 repo 自己的腳本完整路徑，不是裸的檔名片段——避免別的
+    # checkout、備份檔（例如 run_queue.py.bak）之類的命令列片段誤判成
+    # 「已經在跑」，導致該重啟的時候被誤判成略過（CodeRabbit review
+    # 指出的問題）。光是比對完整路徑還不夠：路徑本身也只是子字串，
+    # "run_queue.py.bak" 一樣會匹配到 "run_queue.py" 這個前綴。加邊界
+    # 要求——前面不能接非空白字元（排除更長檔名的一部分），後面要接
+    # 空白或字串結尾，且允許路徑前後可能有的雙引號（Start-Process
+    # 組出的命令行會加）。
+    $pattern = '(?<!\S)"?' + [regex]::Escape($scriptPath) + '"?(?=\s|$)'
+    $existing = Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction Stop |
+        Where-Object { $_.CommandLine -match $pattern }
+
+    if ($existing) {
+        $pids = ($existing | Select-Object -ExpandProperty ProcessId) -join ","
+        Write-SelfLog "$ScriptName 已在跑（PID $pids），略過重複啟動"
+        return
+    }
+
+    Write-SelfLog "偵測到 $ScriptName 沒在跑，自動重啟"
+    $command = '/c python -u "{0}" >> "{1}" 2>&1' -f $scriptPath, $queueLog
+    Start-Process -FilePath "cmd.exe" -ArgumentList $command -WorkingDirectory $repo -WindowStyle Hidden -ErrorAction Stop
+    Write-SelfLog "已呼叫 Start-Process 重啟 $ScriptName"
+}
+
 Write-SelfLog "腳本開始執行"
 
 try {
     Set-Location -Path $repo -ErrorAction Stop
-
-    # 只比對這個 repo 自己的 run_queue.py 完整路徑，不是裸的
-    # "run_queue.py" 片段——避免別的 checkout、備份檔
-    # （run_queue.py.bak）之類的命令列片段誤判成「已經在跑」，
-    # 導致該重啟的時候被誤判成略過（CodeRabbit review 指出的問題）。
-    # 光是比對完整路徑還不夠：路徑本身也只是子字串，"run_queue.py.bak"
-    # 一樣會匹配到 "run_queue.py" 這個前綴。加邊界要求——前面不能接
-    # 非空白字元（排除更長檔名的一部分），後面要接空白或字串結尾，
-    # 且允許路徑前後可能有的雙引號（Start-Process 組出的命令行會加）。
-    $scriptArgumentPattern = '(?<!\S)"?' + [regex]::Escape($scriptPath) + '"?(?=\s|$)'
-    $existing = Get-CimInstance Win32_Process -Filter "Name='python.exe'" -ErrorAction Stop |
-        Where-Object { $_.CommandLine -match $scriptArgumentPattern }
-
-    if ($existing) {
-        $pids = ($existing | Select-Object -ExpandProperty ProcessId) -join ","
-        Write-SelfLog "run_queue.py 已在跑（PID $pids），略過重複啟動"
-        exit 0
-    }
-
-    Write-SelfLog "偵測到佇列執行器沒在跑，自動重啟"
-    $command = '/c python -u "{0}" >> "{1}" 2>&1' -f $scriptPath, $queueLog
-    Start-Process -FilePath "cmd.exe" -ArgumentList $command -WorkingDirectory $repo -WindowStyle Hidden -ErrorAction Stop
-    Write-SelfLog "已呼叫 Start-Process 重啟 run_queue.py"
+    Restart-QueueIfNotRunning -ScriptName "run_queue.py" -LogFile "queue_runner8.log"
+    Restart-QueueIfNotRunning -ScriptName "kaggle_queue.py" -LogFile "kaggle_queue_runner.log"
 }
 catch {
     Write-SelfLog "例外，重啟失敗：$($_.Exception.Message)"


### PR DESCRIPTION
這台機器（Acer AI 16）連續兩次非預期重開機（8/16、8/18）。第二次連 `kaggle_queue.py` 這支輪詢器也一起被砍了。

## 新增
- `recover_running_slots()`：重啟時先掃描待辦項目，查有沒有帳號已經在 Kaggle 端跑著對應的 kernel，找到就接回槽位而不是重推（重推等於中斷已經跑了一段時間的進度）。已實測：復原了 6 個正在跑的 kernel，全部正確接回、沒有重推。
- `acquire_lock()`/`release_lock()`（比照 `run_queue.py` 同一套單例鎖）：手動測試 `restart_queue_on_boot.ps1` 時，發現行程比對因為啟動指令列格式不同而漏配，誤判成「沒在跑」又重啟了一份——`run_queue.py` 因為自己有鎖而安全退出，`kaggle_queue.py` 沒有，兩個同時活著（還沒真的撞出問題就先發現並砍掉了）。這裡補上真正的單例鎖。
- `restart_queue_on_boot.ps1` 重構成同時顧 `run_queue.py` 與 `kaggle_queue.py`（原本只顧前者），兩者都已經有各自的鎖保護，重啟安全。

已在正式環境驗證：手動啟動第二個 `kaggle_queue.py` 會正確偵測到鎖並立刻退出。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增 BHAC15 Gaia 等時線資料下載、轉換、網格建立與格式驗證，支援年齡範圍篩選。
  - 支援分批執行擬合與模擬試驗，使用可重現且互不重複的亂數種子。
  - 工作佇列新增執行鎖、中斷恢復、逾時檢查與更長等待時間。
  - 啟動腳本可自動恢復佇列處理程序。

- **文件**
  - 更新 BHAC15 網格的可用範圍、限制與驗證狀態。
  - 更新工作紀錄及相關任務佇列。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->