### PR TITLE
補齊 B1/B2/B3：五支計算腳本共用意圖對帳與續傳機制

### DIFF
--- a/docs/reference/PREFLIGHT.md
+++ b/docs/reference/PREFLIGHT.md
@@ -62,9 +62,9 @@ P11 十二次跑出來的 alpha 全部精確等於 2.500、散布 0.000 ——**
 | **A1** 解析度自我測試 | 峰值放在已知位置實跑一次搜尋，量它有沒有照宣稱的階數收斂；含反向對照與平行路徑一致性 | `scripts/tools/preflight.py --gate a` |
 | **A2** 設定對帳 | 模型實際生效的值 vs `config.toml` 宣告的值，逐項比對 | 五支計算腳本各自的 `--preflight` |
 | **A3** 網格涵蓋 | 搜尋軸有幾個粗格點落在等時線網格涵蓋之外（會被吸附成幽靈格點） | 同上 |
-| **B1** 意圖對帳 | 這次實際會算幾套設定、幾次重複、幾階精修、實際格距 | 同上（`fit_real.py` 專屬，其餘四支還沒有） |
-| **B2** 輸出衝突 | `--tag` 對應的檔案是否已存在、manifest 設定是否相容 | 同上（`fit_real.py` 專屬） |
-| **B3** 續傳能力 | 這支腳本撐不撐得過中途被砍 | `preflight.py --gate b` |
+| **B1** 意圖對帳 | 這次實際會算幾項掃描（設定／冪次／污染比例／真值／情境）、幾次重複、幾階精修、實際格距 | 同上（五支都有，`preflight.workload_audit()`） |
+| **B2** 輸出衝突 | `--tag` 對應的檔案是否已存在、manifest 設定是否相容 | 同上（五支都有，`preflight.output_audit()`） |
+| **B3** 續傳能力 | 這支腳本撐不撐得過中途被砍 | `preflight.py --gate b`（五支都有，`scripts/tools/checkpoint.py`） |
 | **C1** 量化簽章 | 最佳點是否全落在粗網格節點（可疑訊號，需搭配實際解析度或搜尋軌跡判定，不是必然＝沒精修）、重複間散布是否精確 0、有無貼牆 | `preflight.py --gate c` |
 | **C2** manifest 完整性 | 沒有 manifest 的結果檔無法事後查證設定 | 同上 |
 
@@ -86,15 +86,15 @@ x64 協作機都是直接執行 `python fit_real.py ...`，完全不經過
 `sys.exit(1)`，除非帶 `--force`（僅供已經看過警告、確認要略過的情況
 使用，不是日常流程）。
 
-**五支腳本現在的涵蓋範圍**：
+**五支腳本現在的涵蓋範圍**（2026-08-20 補上 B1／B2／B3 之後）：
 
 | 腳本 | A1 演算法本身 | A2 設定對帳 | A3 網格涵蓋 | B1／B2 意圖對帳／輸出衝突 | B3 續傳 |
 |---|---|---|---|---|---|
 | `fit_real.py` | 共用（`preflight.py --gate a`） | 有 | 有 | 有 | 有 |
-| `profile_lowmass.py` | 共用 | 有 | 有 | 無 | **無** |
-| `profile_outlierfrac.py` | 共用 | 有 | 有 | 無 | **無** |
-| `inject_lowmass.py` | 共用 | 有 | 有 | 無 | **無** |
-| `injection_recovery.py` | 共用 | 有 | 有 | 無 | **無** |
+| `profile_lowmass.py` | 共用 | 有 | 有 | 有 | 有 |
+| `profile_outlierfrac.py` | 共用 | 有 | 有 | 有 | 有 |
+| `inject_lowmass.py` | 共用 | 有 | 有 | 有 | 有 |
+| `injection_recovery.py` | 共用 | 有 | 有 | 有 | 有 |
 
 A1 是共用的：`multi_stage_best()` 是這五支腳本都在用的同一份搜尋演算法，
 驗證它本身的正確性只需要做一次，不需要每支腳本各自重複。A2／A3 集中在
@@ -116,15 +116,72 @@ A1 是共用的：`multi_stage_best()` 是這五支腳本都在用的同一份�
 （`_preflight_ok()`）跟 `preflight.py` 的 `gate_b()` 都改吃這個常數，
 不再只認 `fit_real.py`。
 
-**這輪沒做的部分，誠實記在這裡**：
-- **B1／B2（意圖對帳、輸出衝突）還只有 `fit_real.py` 有**——其餘四支
-  的旗標介面互不相同（`--trials` vs `--repeats`、`--scenarios` vs
-  `--slopes`／`--fracs` 等），沒有硬套同一份邏輯，需要各自設計才能做，
-  這次沒做。
-- **B3（續傳）本身沒有解決，只是多了 A2／A3 這層保護**——四支診斷腳本
-  仍然只在最後 `np.savez` 一次，中途被砍一樣得從頭重算。這是完全不同
-  的兩個問題：A2／A3 防的是「設定錯了但沒人發現」，B3 防的是「設定
-  對，但被外力（Windows 重開機）中斷後浪費掉」。這次只做了前者。
+## 2026-08-20（同日稍晚）：B1／B2 推廣到五支腳本、B3 補齊四支診斷腳本
+
+上面那節寫完後留了兩個誠實記錄的缺口，同一天內都補上了：
+
+**B1／B2（意圖對帳、輸出衝突）不再是 `fit_real.py` 專屬**：原本卡住的
+理由是「五支腳本旗標介面互不相同（`--configs` vs `--slopes`／`--fracs`
+vs `--trials`+`--only` vs `--scenarios`），沒辦法硬套同一份邏輯」。
+解法不是讓共用函式認得每支腳本的旗標名稱，而是反過來——
+`preflight.workload_audit()`／`output_audit()` 只認一組共同形狀
+（`scan_keys`＋每個 key 重複幾次），每支腳本自己把旗標轉換成這組形狀
+再呼叫。`fit_real.py` 也一併重構成呼叫這兩支共用函式（原本它自己手寫
+一份幾乎一樣的邏輯），不是只有新加入的四支在用，同一套實作沒有分裂
+成「舊的一份、新的一份」。連帶把 `injection_recovery.py` 原本
+「未知情境靜默略過、只印一行」的行為升級成跟 `fit_real.py` 打錯
+`--configs` 名稱一樣的處理：先在 `workload_audit()` 報成可被
+`--force` 略過的阻擋，再加一道不能被 `--force` 繞過的硬 `sys.exit(1)`。
+
+**B3（續傳）補齊 `profile_lowmass.py`／`profile_outlierfrac.py`／
+`inject_lowmass.py`／`injection_recovery.py`**：抽出新模組
+`scripts/tools/checkpoint.py`，把 `fit_real.py` 原本自己的
+`atomic_savez()`／存取鎖／`load_partial()`／manifest 比對整組邏輯收斂
+成共用實作（`fit_real.py` 自己也改成呼叫這份，不再維護複本——這正是
+上一節「檢查程式不要自己複製一份」那條原則，這次換到續傳邏輯上重演，
+提前收斂掉）。四支診斷腳本原本要嘛完全沒有（`profile_lowmass.py`／
+`profile_outlierfrac.py`／`injection_recovery.py`，只在全部掃描點跑完
+後 `np.savez` 一次），要嘛做到一半（`inject_lowmass.py` 每個注入真值
+存一次，但重啟不會讀回既有進度，一樣會重算），現在全部改成每算完
+一次（`inject_lowmass.py`／`injection_recovery.py` 是每次試驗，
+`profile_lowmass.py`／`profile_outlierfrac.py` 是每次重複）就存一次。
+
+`checkpoint.save_progress()` 另外用一個 `attempted`（已嘗試次數，跟
+`len(results)`／已成功次數分開記）處理 `inject_lowmass.py` 會遇到的
+貼牆例外——某次試驗因為 `WallError`／`CornerError`失敗，那個試驗索引
+真的跑過一次，續傳時不該重跑（重跑只會用同一組亂數種子再得到同一個
+失敗結果，白工）。`injection_recovery.py` 的 `multi_stage_best()`
+呼叫帶 `raise_on_wall=False`（貼牆只印警告不丟例外），每次嘗試必定
+成功，不需要這層區分，用法上比 `inject_lowmass.py` 簡單。
+
+**過程中連帶抓到一個真實的 Windows bug**：用高速迴圈測試連續存檔時，
+`os.replace()` 偶發 `PermissionError: [WinError 5]`——根因是
+`np.load()` 回傳的 `NpzFile` 沒有用 `with` 關閉，refcount 歸零不保證
+CPython 立刻真的關掉底層檔案控制代碼，短時間內連續呼叫會讓控制代碼
+卡住後續的 `os.replace()`。已修正 `load_partial()`／`load_manifest()`
+一律用 `with` 讀取。修完之後在同一支測試腳本上又用不同情境重現一次
+（這次無關檔案控制代碼——三次一模一樣的呼叫裡有一次還是炸掉），判斷是
+Windows 上防毒軟體／索引服務對剛寫完的暫存檔做即時掃描造成的短暫佔用，
+不是程式碼邏輯錯誤；改成對 `os.replace()` 的 `PermissionError` 做有
+上限（6 次、每次間隔遞增）的重試，跟 `acquire_write_lock()` 對付另一個
+行程持有鎖檔是同一類「等一下再試」的處置，重試次數用完仍失敗才真的
+往上拋。真實產線的兩次存檔間隔是幾分鐘（一次完整的擬合），這個窗口
+在實機上幾乎不可能撞到，但既然用自動化測試踩過就照實修掉，不留著
+當僥倖。
+
+**驗證方式**：五支腳本各自 `--preflight` dry-run 過（含故意給不存在的
+設定／情境名稱、確認阻擋正確觸發）；`checkpoint.py` 的
+`save_progress()`／`load_progress()`／`check_manifest()` 直接單元測試過
+（含跨行程競態、legacy 檔案相容性、`gate_c()` 對 `__attempted_*` 記帳鍵
+的排除）；`inject_lowmass.py`／`injection_recovery.py`／
+`profile_lowmass.py` 各自用假的 `multi_stage_best()`／`make_fake()`
+（跳過真正的合成星團運算，只驗證存檔／續傳這條路徑本身）跑過完整的
+「執行一次→中斷→重啟」流程，確認第二次執行時已完成的項目一律被跳過、
+不會重算。沒有花機時去真正等一次完整的診斷腳本跑完（`inject_lowmass.py`
+單一次試驗 `--procs 1` 實測要 385 分鐘），這條路徑目前只驗證到「存檔／
+續傳的機制本身正確」，不含「真正的擬合流程跑完全程不出錯」——那個
+信心來自這些函式本來就是 `fit_real.py` 已經在生產環境跑了幾天的同一套
+邏輯（`checkpoint.py` 是從它抽出來的），不是全新未驗證的東西。
 
 ## 建立當下就抓到的東西
 
@@ -147,25 +204,31 @@ A1 是共用的：`multi_stage_best()` 是這五支腳本都在用的同一份�
    分不出來，因為輸出只記最佳點、沒記達成的解析度。而 `r1 = 2.10` 正是
    「α 由核心往外圍上升」這個梯度主張的錨點。`radial_r1_final`
    （`--refines 3,3 --repeats 5`）會重跑它，這個疑慮會自然解掉。
-4. **四支腳本沒有續傳**——`profile_lowmass.py`、`profile_outlierfrac.py`、
-   `injection_recovery.py`、`inject_lowmass.py` 都只在最後 `np.savez`
-   一次，只有 `fit_real.py` 有逐次存檔＋manifest 續傳。而這台機器過去
-   四天被 Windows 強制重開機至少 4 次（`Get-WinEvent` 的 1074/109 事件，
-   多半是「其他（不在計劃之中）」，8/19 21:11 那次還是非正常關機），
-   `p6_lowmass_v2` 因此從 8/16 起連續四天每次都從頭重算、一次都沒跑完。
+4. **四支腳本沒有續傳**（**已在同日稍晚補上，見上方「B1／B2 推廣到
+   五支腳本、B3 補齊四支診斷腳本」一節**）——`profile_lowmass.py`、
+   `profile_outlierfrac.py`、`injection_recovery.py`、`inject_lowmass.py`
+   原本都只在最後 `np.savez` 一次，只有 `fit_real.py` 有逐次存檔＋
+   manifest 續傳。而這台機器過去四天被 Windows 強制重開機至少 4 次
+   （`Get-WinEvent` 的 1074/109 事件，多半是「其他（不在計劃之中）」，
+   8/19 21:11 那次還是非正常關機），`p6_lowmass_v2` 因此從 8/16 起
+   連續四天每次都從頭重算、一次都沒跑完。
 
 ## 已知涵蓋缺口（不要把「放行」讀成「檢查過了」）
 
-- **B1／B2 只有 `fit_real.py` 有**（意圖對帳、輸出衝突），其餘四支
-  只有 A2／A3。`preflight.py --gate b` 會逐行印出每一項待跑工作實際
-  受到哪一種等級的檢查。
-- **B3（續傳）在 `run_queue.py` 裡是警告不是阻擋，且四支診斷腳本本身
-  仍然沒有續傳機制。** A2／A3 現在會自動跑，但跑到一半被 Windows 強制
-  重開機一樣會歸零重算——這是完全不同的兩個問題（見上一節結尾），
-  這次只解決了「設定錯了沒人發現」，沒解決「設定對但被中斷就浪費掉」。
-  根治要幫這四支腳本補上 `fit_real.py` 那套逐次存檔＋manifest 續傳。
-- **Windows 非預期重開機本身沒有處理。** 這是上面那條的另一半，屬於
-  機器設定不是程式碼。
+- **B1／B2／B3 現在五支腳本都有**（2026-08-20 同日稍晚補齊，見上方
+  對應章節）。`preflight.py --gate b` 仍然會逐行印出每一項待跑工作
+  實際受到哪一種等級的檢查——五支現在應該全部顯示齊全，如果哪天新增
+  第六支計算腳本忘了接上這套機制，這裡會照實顯示出涵蓋缺口，不會
+  誤報成「查過了」。
+- **B3 續傳目前只驗證到機制本身（存檔／續傳邏輯），沒有跑過一次完整
+  的真實擬合流程去確認「續傳後接著跑的真實計算不出錯」。** 驗證方式
+  是用假的 `multi_stage_best()` 跳過真正的合成星團運算（見上方章節
+  的「驗證方式」小節），信心來自這套邏輯是從已經在生產環境跑了幾天的
+  `fit_real.py` 抽出來的共用模組，不是全新沒被驗證過的東西，但誠實
+  記錄「還沒有一次端到端的真實續傳＋算完全程」這件事沒有發生過。
+- **Windows 非預期重開機本身沒有處理。** 這是造成 B3 需求的根本原因，
+  屬於機器設定不是程式碼，這次的修法是讓程式撐得過中斷，不是讓中斷
+  不發生。
 - **A1 只測搜尋演算法本身。** 它驗證 `multi_stage_best()` 會照宣稱的
   階數收斂，不驗證概似函數、合成星團生成、選擇函數這些的正確性——
   那些要靠注入回收，而注入回收測不到等時線的物理誤差（見

--- a/fit_real.py
+++ b/fit_real.py
@@ -497,13 +497,32 @@ def main():
         # `TypeError: list indices must be integers or slices, not tuple`
         # （這是既有 bug，續傳測試時發現，跟這次的 checkpoint 重構本身
         # 無關但同一條路徑上，一併修掉）。
-        out[key] = np.array(reps)
+        #
+        # 再截一次 [:args.repeats]：`checkpoint.save_progress()` 偵測到
+        # 磁碟上有另一個行程寫入更新的版本時，會直接回傳磁碟上的完整
+        # `reps`（見該函式「改沿用磁碟版本繼續」那段）——那份完整版本
+        # 可能比這次 `args.repeats` 要求的多，不截斷的話跨行程競態下
+        # 統計筆數又會跟這次要求的次數對不上，同一顆問題（見上面
+        # 主迴圈前 `out = {...}[:args.repeats]` 那次修正）在跨行程續傳
+        # 這條路徑上重演一次（2026-08-20 CodeRabbit review）。
+        out[key] = np.array(reps[:args.repeats])
         arr = out[key]
         if args.repeats > 1:
             print(f"{key} 跨 {args.repeats} 次：alpha 平均 {arr[:,3].mean():.3f}"
                   f"、散布 {arr[:,3].std():.3f}"
                   f"（{'  '.join(f'{v:.3f}' for v in arr[:,3])}）\n", flush=True)
 
+    # 上面 `out[key] = np.array(...)` 的轉型只發生在 `for key in
+    # requested:` 迴圈內，只碰得到這次 `--configs` 選到的設定——`out`
+    # 裡若還混著這次沒選、只是沿用舊 checkpoint 殘留的設定（例如上例的
+    # A），那些鍵仍停在最初 `out = {k: list(v)[:args.repeats] for ...}`
+    # 給的原始 list，下面 `out[key][:, 3]` 會丟
+    # `TypeError: list indices must be integers or slices, not tuple`
+    # ——跟前面那個「全部 repeats 都被續傳跳過」的既有 bug 同一個形狀，
+    # 換成「這個 key 這次根本沒被主迴圈碰過」這個變體，一併在這裡收尾
+    # 統一轉型修掉，不用在每個可能少碰到某個 key 的分支各自補一次
+    # （2026-08-20 CodeRabbit review 抓到「A 混進 C 的統計」才發現）。
+    out = {k: np.asarray(v) for k, v in out.items()}
     print(f"{'='*74}\nalpha 隨模型設定的變化\n{'='*74}")
     print(f"{'設定':<6}{'說明':<34}{'alpha 平均':>11}{'散布':>8}{'相對 A':>10}")
     a0 = out["A"][:, 3].mean() if "A" in out else np.nan
@@ -511,7 +530,15 @@ def main():
         a = out[key][:, 3]
         print(f"{key:<6}{CONFIGS[key][0]:<34}{a.mean():>11.3f}"
               f"{a.std():>8.3f}{a.mean()-a0:>+10.3f}")
-    if "A" in out and "C" in out and args.repeats > 1:
+    # 除了 args.repeats > 1，還要求 A／C 兩邊「這次手上的筆數」本身
+    # 都 > 1：`out` 裡可能混著這次沒被 --configs 選到、只是沿用舊
+    # checkpoint 殘留筆數的設定（例如舊檔只有 A 的 1 筆結果，這次跑
+    # `--configs C --repeats 2`，A 完全沒被這次的主迴圈碰過，`out["A"]`
+    # 停在 1 筆）——用 `args.repeats > 1` 判斷不出這種情況，`len(out["A"])`
+    # 只有 1 時 `var(ddof=1)` 除以 (1-1)=0 會靜默產生 nan，混進看起來
+    # 正常的位移報表裡（2026-08-20 CodeRabbit review）。
+    if "A" in out and "C" in out and args.repeats > 1 \
+            and len(out["A"]) > 1 and len(out["C"]) > 1:
         # 位移要與重現性比較才有意義。兩組各自的散布合併成位移的標準誤。
         na, nc = len(out["A"]), len(out["C"])
         se = np.sqrt(out["A"][:, 3].var(ddof=1) / na

--- a/fit_real.py
+++ b/fit_real.py
@@ -41,7 +41,6 @@ system MF **陡**：f_bin=0.30 -> +0.046、0.45 -> +0.066、0.60 -> +0.085、
 from __future__ import annotations
 
 import argparse
-import json
 import os
 import sys
 import time
@@ -49,10 +48,19 @@ from pathlib import Path
 
 import numpy as np
 
-# 存在輸出 npz 裡的一個保留鍵，記錄「這批部分結果是用什麼設定算出來的」
-# （見 build_manifest() / main() 裡的比對邏輯）。用雙底線包住避免跟
-# CONFIGS 的單字母鍵（A/B/C/D）或未來可能加的設定名稱撞名。
-MANIFEST_KEY = "__manifest__"
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE / "scripts" / "tools"))
+import checkpoint                                                 # noqa: E402
+
+# 沿用 checkpoint.py 的保留鍵名（雙底線包住避免跟 CONFIGS 的單字母鍵
+# A/B/C/D 或未來可能加的設定名稱撞名）。2026-08-20 起續傳的底層機制
+# （atomic_savez／存取鎖／load_partial）搬進 scripts/tools/checkpoint.py
+# 共用模組，這裡不再自己維護一份——這支腳本原本是唯一有這套機制的，
+# 抽成共用模組後，另外四支診斷腳本才有辦法直接沿用同一套，不用各自
+# 重新發明（同一個道理已經在 preflight.audit_common() 上發生過一次：
+# fit_real.py 自己另外維護的一份跟共用版本不同步過，見下面
+# _preflight_report() 的說明）。
+MANIFEST_KEY = checkpoint.MANIFEST_KEY
 
 
 def build_manifest(args) -> dict:
@@ -91,7 +99,6 @@ MANIFEST_LEGACY_DEFAULTS = {
     "repeat_offset": 0,
 }
 
-HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
 from pipeline import config as cfgmod, isochrones as isomod   # noqa: E402
@@ -101,147 +108,57 @@ from measure_overconfidence import GRID                       # noqa: E402
 from injection_recovery import COARSE, multi_stage_best       # noqa: E402
 
 
-def atomic_savez(out_path: Path, **arrays):
-    """np.savez 不是原子操作，寫到一半被中斷會留下截斷或空檔案。改成寫到
-    同目錄的暫存檔，成功才用 os.replace() 原子性換過去（跟
-    inject_lowmass.py 的 atomic_savez() 同一個理由、同一套寫法）。"""
-    tmp_path = out_path.with_name(out_path.stem + ".tmp.npz")
-    try:
-        np.savez(tmp_path, **arrays)
-        os.replace(tmp_path, out_path)
-    except BaseException:
-        try:
-            tmp_path.unlink()
-        except FileNotFoundError:
-            pass
-        raise
+def _preflight_gate(args, model, grid, refines, configs,
+                    out_path, partial, n_obs) -> None:
+    """開跑前檢查：把「這次到底會算什麼」攤開來。只讀不寫，不碰任何
+    結果檔。有阻擋級問題時視 `args.force`／`args.preflight` 決定要不要
+    中止（實際的中止/繼續邏輯在 `preflight.mandatory_gate()` 裡，見下）。
 
-
-def _acquire_write_lock(out_path: Path, timeout_s: float = 1800.0):
-    """對 out_path 的存檔操作加互斥鎖，避免兩個用同一個 --tag 的行程同時
-    讀-改-寫同一份 npz（2026-08-15 CodeRabbit review：atomic_savez() 只
-    保證單次 os.replace() 不會留下半檔，不保護 load_partial() 到
-    atomic_savez() 之間的整段讀-改-寫——兩個行程各自讀到舊快照、各自
-    加上自己新算出的重複再存檔，後存的會整批覆蓋掉先存的那些新結果）。
-
-    做法跟 run_queue.py 的 acquire_lock() 同一套 O_CREAT|O_EXCL 原子建立
-    模式（該檔已用這個模式解決過同一類競態，這裡不重新發明）。**這只解決
-    「檔案不會被覆蓋壞掉」，不解決「兩個行程各算了一份 rep 0 卻只留得住
-    一份」**——要跨機器/帳號真正平行擴充同一批 repeats，還是要搭配不重疊
-    的 repeat 索引（例如各自用不同 --tag 各出一個分片檔，跑完再手動合併），
-    不是這個鎖能單獨補上的，見 fit_real.py 開頭這段留言與 PR #53 review。
-    """
-    lock_path = out_path.with_name(out_path.name + ".lock")
-    lock_path.parent.mkdir(parents=True, exist_ok=True)
-    t0 = time.time()
-    while True:
-        try:
-            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
-            os.close(fd)
-            return lock_path
-        except FileExistsError:
-            if time.time() - t0 > timeout_s:
-                print(f"警告：等待 {lock_path.name} 超過 {timeout_s:.0f} 秒"
-                      f"（可能是上一個行程異常結束沒清掉鎖檔），強制視為"
-                      f"可以繼續，手動確認沒有另一個行程還在寫這個檔案。",
-                      flush=True)
-                try:
-                    lock_path.unlink()
-                except FileNotFoundError:
-                    pass
-                continue
-            time.sleep(0.5)
-
-
-def _release_write_lock(lock_path: Path):
-    try:
-        lock_path.unlink()
-    except FileNotFoundError:
-        pass
-
-
-def load_partial(out_path: Path) -> dict:
-    """載入上次中斷前已經存檔的部分結果，讓 main() 可以跳過已經算完的
-    (config, rep) 組合，不必整批重算（2026-08-15：run_queue.py 需要重啟
-    套用電源管理修正時，發現原本的存檔邏輯要等全部 configs/repeats 都跑完
-    才存一次，中途被砍全部白工，即使每一次重複本身花好幾小時。改成每跑完
-    一次重複就存一次，重跑時先讀回已有的部分結果）。"""
-    if not out_path.exists():
-        return {}
-    try:
-        d = np.load(out_path)
-        return {k: np.asarray(d[k]) for k in d.files}
-    except Exception as e:                                    # noqa: BLE001
-        print(f"警告：讀取既有部分結果 {out_path} 失敗（{e}），"
-              f"視為沒有可續傳的進度，從頭開始。", flush=True)
-        return {}
-
-
-def _preflight_report(args, model, grid, refines, configs,
-                      out_path, partial, n_obs) -> int:
-    """`--preflight` 的內容：把「這次到底會算什麼」攤開來，回傳退出碼。
-
-    只讀不寫，不碰任何結果檔。回傳 0 代表通過、非 0 代表有阻擋級問題。
-
-    分兩部分：
-      工作量   對應 radial_r1 漏帶 `--configs C`（6 機時）——把「實際會算
-               幾套模型、幾次重複」印出來，跟意圖不符一眼看得出來，是
-               fit_real.py 專屬的 B1（意圖對帳）／B2（輸出衝突），其餘
-               四支腳本旗標介面互不相同沒有共用
-      解析度／設定對帳／網格涵蓋 對應 A1/A2/A3——**2026-08-20 起改成呼叫
-      `preflight.audit_common()`，不再自己維護一份**：這三段原本在這裡
-      跟 `scripts/tools/preflight.py` 的 `audit_common()` 各自獨立實作
-      同一套邏輯，結果 CodeRabbit review 抓到「`--refines 1` 沒有實際
-      精修效果卻只被當警告放行」這個 bug 時，我只修了 `audit_common()`
-      那一份，這裡的複本沒有跟著修——兩份會各自演化然後不同步，正是
-      這整個 PREFLIGHT 機制想防的那種問題形狀，換個地方在自己身上重演。
-      改成直接呼叫共用函式，不可能再發生「修一邊漏一邊」。
+    2026-08-20 起分兩段，都改成呼叫共用函式，不再自己維護實作：
+      B1（意圖對帳）／B2（輸出衝突） 原本是 fit_real.py 專屬（其餘四支
+          腳本旗標介面互不相同，沒有共用），現在透過
+          `preflight.workload_audit()`／`output_audit()` 收斂成同一套
+          邏輯——那兩支函式不需要認得每支腳本的旗標名稱，呼叫端只要把
+          自己的旗標轉換成同一組共同形狀（scan_keys＋repeats）即可，
+          fit_real.py 是第一個套用者，另外四支腳本比照辦理。
+      A1/A2/A3（解析度／設定對帳／網格涵蓋） 呼叫
+          `preflight.mandatory_gate()`（內部呼叫 `audit_common()`）。
+          這三段原本在這裡跟 `scripts/tools/preflight.py` 各自獨立實作
+          同一套邏輯，CodeRabbit review 抓到「`--refines 1` 沒有實際
+          精修效果卻只被當警告放行」這個 bug 時，我只修了共用版本，
+          這裡的複本沒有跟著修——兩份各自演化然後不同步，正是這整個
+          PREFLIGHT 機制想防的問題形狀，換個地方在自己身上重演。
+          `mandatory_gate()` 同時接手中止/繼續/`--force` 的判定，這裡
+          不用再自己重複一次同樣的邏輯。
     """
     sys.path.insert(0, str(HERE / "scripts" / "tools"))
     import preflight                                          # noqa: E402
-    fails, warns = [], []
-    P = lambda s="": print(s, flush=True)                    # noqa: E731
 
-    P("=" * 74)
-    P("開跑前檢查（--preflight）：只檢查，不擬合")
-    P("=" * 74)
-
-    # --- 1. 這次實際會算什麼（意圖對帳）---
+    # --- B1：這次實際會算什麼（意圖對帳）---
     keys = [k.strip().upper() for k in args.configs.split(",")]
     valid = [k for k in keys if k in configs]
     unknown = [k for k in keys if k not in configs]
-    if unknown:
-        # main() L~560 對打錯的設定名稱是靜默用交集過濾掉（同樣的邏輯
-        # 這裡的 valid 也是）——`--configs A,X` 會讓 X 被無聲丟棄，preflight
-        # 通過、擬合照跑，但算出來的設定跟意圖不同。這正是本段「意圖
-        # 對帳」要抓的形狀，所以升級成阻擋，不能只當警告放行
-        #（2026-08-20 CodeRabbit review）。
-        fails.append(f"--configs 有不存在的設定名稱 {unknown}"
-                     f"（可用：{', '.join(configs)}），它們會被靜默略過，"
-                     f"實際只會算 {valid}")
-    n_new = sum(max(0, args.repeats - len(partial.get(k, []))) for k in valid)
-    P("\n【工作量】")
-    P(f"  設定（--configs）  {', '.join(valid)}"
-      f"（{len(valid)} 套）")
-    P(f"  每套重複           {args.repeats} 次"
-      f"（offset {args.repeat_offset}）")
-    P(f"  已完成、會跳過     "
-      f"{ {k: len(v) for k, v in partial.items()} or '無'}")
-    P(f"  這次實際要算       {n_new} 次擬合")
-    P(f"  精修階數           {refines}"
-      f"（粗網格 + {len(refines)} 階精修）")
-    P(f"  合成星數 n_syn     {args.n_syn:,}")
-    P(f"  觀測星數           {n_obs:,}")
+    # main() 對打錯的設定名稱另外還有一道不能被 --force 繞過的硬阻擋
+    # （見 main() 該處註解）；這裡的 unknown 只影響 workload_audit 的
+    # fails，走的是跟其餘 A2/A3 問題一樣「可以 --force 略過」的路徑，
+    # 兩者用途不同、都要留著。
+    partial_counts = {k: len(v) for k, v in partial.items()}
+    w_fails, w_warns = preflight.workload_audit(
+        scan_keys=valid, repeats=args.repeats, n_syn=args.n_syn,
+        n_obs=n_obs, refines=refines, partial_counts=partial_counts,
+        unit="次重複", unknown=unknown, known=list(configs),
+        scan_label="設定（--configs）")
     if len(valid) > 1:
-        warns.append(f"會算 {len(valid)} 套設定（{', '.join(valid)}），"
-                     f"耗時約為單一設定的 {len(valid)} 倍——"
-                     f"若只要 config C，記得帶 --configs C"
-                     f"（radial_r1 就是漏帶這個白算了 6 機時）")
-    if n_new == 0:
-        warns.append("這次沒有任何新的擬合要算（既有結果已滿足 --repeats），"
-                     "跑起來會立刻結束")
+        w_warns.append(f"會算 {len(valid)} 套設定（{', '.join(valid)}），"
+                       f"耗時約為單一設定的 {len(valid)} 倍——"
+                       f"若只要 config C，記得帶 --configs C"
+                       f"（radial_r1 就是漏帶這個白算了 6 機時）")
 
-    # --- 2/3/4. 解析度／設定對帳／網格涵蓋：共用邏輯 ---
+    # --- B2：輸出檔狀態 ---
+    preflight.output_audit(out_path, partial)
+
+    # --- A1/A2/A3：解析度／設定對帳／網格涵蓋，併入 B1 算出的 fails/warns
+    # 一起判定 ---
     # **刻意讓 audit_common() 直接重讀 config.toml 原始檔案，不是傳
     # main() 已經解析好的 cfg 物件**：A2 那個 bug 的形狀正是「cfg 讀進來
     # 之後，程式碼又用 cfg._data[...]=... 動態覆寫掉某個值」。如果改成
@@ -249,29 +166,10 @@ def _preflight_report(args, model, grid, refines, configs,
     # 永遠對得起來，等於讓這段檢查失去意義。fit_real.py 不像其餘四支
     # 診斷腳本那樣刻意覆寫 mh_prior_sigma，所以不傳 expected_overrides
     # ——如果哪天 fit_real.py 也悄悄多了一行覆寫，這裡會如實抓到。
-    audit_fails, audit_warns = preflight.audit_common(
-        model, grid, refines, script="fit_real.py")
-    fails.extend(audit_fails)
-    warns.extend(audit_warns)
-
-    # --- 5. 輸出檔狀態 ---
-    # manifest 不相容的情況在上游已經 sys.exit(1) 擋掉了，走到這裡只會是
-    # 「沒有舊檔」或「舊檔相容」，所以這段是報告不是判斷。
-    P("\n【輸出】")
-    P(f"  檔案               results/{out_path.name}")
-    P(f"  目前狀態           "
-      f"{'已存在，設定相容，會續傳' if partial else '不存在，從頭開始'}")
-    P(f"  續傳保護           有（每次重複算完立刻存檔＋寫入鎖）")
-
-    P("\n" + "=" * 74)
-    for w in warns:
-        P(f"  注意：{w}")
-    for f in fails:
-        P(f"  阻擋：{f}")
-    P(f"結論：{'不通過' if fails else '通過'}"
-      f"（阻擋 {len(fails)}、注意 {len(warns)}）")
-    P("=" * 74)
-    return 1 if fails else 0
+    preflight.mandatory_gate(
+        model, grid, refines, script="fit_real.py",
+        force=args.force, dry_run=args.preflight,
+        extra_fails=w_fails, extra_warns=w_warns)
 
 
 def main():
@@ -462,60 +360,31 @@ def main():
     from pipeline.step3_age import draw_randoms
     out_path = HERE / "results" / f"fit_real{args.tag}.npz"
     manifest = build_manifest(args)
-    partial_raw = load_partial(out_path)
-    old_manifest_arr = partial_raw.pop(MANIFEST_KEY, None)
-    partial = partial_raw
+    partial = checkpoint.load_partial(out_path)
+    checkpoint.check_manifest(out_path, manifest, partial,
+                              legacy_defaults=MANIFEST_LEGACY_DEFAULTS)
     if partial:
-        if old_manifest_arr is None:
-            # 舊檔案沒存過 manifest（這個檢查是 2026-08-15 才加的），沒有
-            # 東西可比對——信任沿用，不因為缺 manifest 就拒絕續傳既有進度。
-            print(f"警告：{out_path.name} 是加 manifest 檢查前存的舊檔，"
-                  f"無法自動確認這次的設定跟它一致，視為信任沿用。",
-                  flush=True)
-        else:
-            old_manifest = json.loads(str(old_manifest_arr))
-
-            def _old(k):
-                return old_manifest.get(k, MANIFEST_LEGACY_DEFAULTS.get(k))
-
-            diffs = {k: (_old(k), v) for k, v in manifest.items()
-                     if _old(k) != v}
-            if diffs:
-                print(f"錯誤：{out_path.name} 已有部分結果，但執行設定跟"
-                      f"這次不同（{diffs}）。沿用會把兩種不可比的設定混進"
-                      f"同一個檔案——換一個 --tag，或確認要不要刪掉舊檔"
-                      f"重跑。", flush=True)
-                sys.exit(1)
         n_done = {k: len(v) for k, v in partial.items()}
         print(f"讀到既有部分結果 {out_path.name}：{n_done}"
               f"（會跳過已經算完的重複，不是從頭重算）\n", flush=True)
     out = {k: list(v) for k, v in partial.items()}
-    if args.preflight:
-        sys.exit(_preflight_report(args, base, grid, refines,
-                                   CONFIGS, out_path, out, len(color)))
     # **2026-08-20 改成無條件執行，不再只有 --preflight 才做**：這份檢查
     # 原本只在有人記得多打一個旗標時才會發生，但實際會呼叫這支腳本的
     # 地方不只 run_queue.py（那邊確實有記得先呼叫 --preflight）——Kaggle
     # 筆記本、x64 協作機手動下指令，都是直接跑 `python fit_real.py ...`，
     # 完全不經過任何會記得先檢查的中介層。讓檢查本身變成 main() 一部分，
     # 不管從哪台機器、哪種方式呼叫，都跑得到，不依賴呼叫端的記性。
-    # 有阻擋級問題就中止，除非 --force（僅供已經看過警告、確認要略過的
-    # 情況使用，不是日常流程）。
-    rc = _preflight_report(args, base, grid, refines, CONFIGS, out_path,
-                           out, len(color))
-    if rc and not args.force:
-        print("開跑前檢查沒通過，中止（用 --force 可以略過，但要先確認"
-              "上面每一條阻擋的理由）", flush=True)
-        sys.exit(rc)
-    if rc and args.force:
-        print("警告：用 --force 略過了上面的阻擋，繼續執行", flush=True)
+    # 中止/繼續/--force 的判定都在 preflight.mandatory_gate() 裡（見
+    # _preflight_gate()），這裡不用再自己重複一次。
+    _preflight_gate(args, base, grid, refines, CONFIGS, out_path, out,
+                    len(color))
     # 打錯的設定名稱要當場中止，不能像下面迴圈那樣用 `if key not in
     # CONFIGS: continue` 靜默略過——`--configs A,X` 打錯字時，沒有這段
     # 驗證的話會悄悄只算 A，結果檔看起來正常，只是少了一個誰都不知道
-    # 該存在的設定，跟 `--preflight` 那份「意圖對帳」要防的是同一種錯
-    #（2026-08-20 CodeRabbit review：這裡跟 `_preflight_report()` 各自
-    # 過濾一次，preflight 那份只用來報告不影響真正執行，這裡才是真正
-    # 會不會跑錯的把關）。
+    # 該存在的設定，跟 `_preflight_gate()` 那份「意圖對帳」要防的是同一種
+    # 錯（2026-08-20 CodeRabbit review：這裡跟 `_preflight_gate()` 各自
+    # 過濾一次，preflight 那份只用來報告、可以被 --force 略過，這裡才是
+    # 真正會不會跑錯的把關，不能被 --force 繞過）。
     requested = [k.strip().upper() for k in args.configs.split(",")]
     unknown = [k for k in requested if k not in CONFIGS]
     if unknown:
@@ -590,32 +459,12 @@ def main():
             # 跑完一次重複就存一次，不等這個 config 的全部 repeats 或
             # 全部 configs 都跑完——中途被砍（不管是意外還是像這次一樣
             # 為了套用別的修正主動重啟），已經算完的每一次重複都保得住，
-            # 重跑時 load_partial() 會讀回來跳過，不會白工。
-            #
-            # 存檔前先拿鎖、重新讀一次磁碟上的最新版本再合併——如果磁碟上
-            # 這個 key 的重複數已經比我們手上這份多（代表有另一個行程用
-            # 同一個 --tag 平行在跑，且比我們快），採用磁碟版本，不要用
-            # 自己比較舊的覆蓋過去。這解決的是「檔案被覆蓋壞掉／新結果
-            # 被舊結果蓋掉」，不解決「兩個行程各自算了一份同樣的 rep 卻
-            # 只留得住一份」——真要跨機器平行擴充同一批 repeats，必須用
-            # 不重疊的 repeat 索引分開跑（每個行程各自的 --tag），這裡的
-            # 鎖只是最後一道防線，見 _acquire_write_lock() 的說明。
-            lock_path = _acquire_write_lock(out_path)
-            try:
-                fresh = {k: v for k, v in load_partial(out_path).items()
-                         if k != MANIFEST_KEY}
-                if len(fresh.get(key, [])) > len(reps):
-                    print(f"  [注意] 磁碟上 {key} 已有 "
-                          f"{len(fresh[key])} 次重複，比這個行程手上的 "
-                          f"{len(reps)} 次多（可能有另一個行程平行在跑同一個 "
-                          f"--tag），改沿用磁碟版本繼續。", flush=True)
-                    reps = list(fresh[key])
-                out.update({k: v for k, v in fresh.items() if k != key})
-                out[key] = np.array(reps)
-                manifest_arr = np.array(json.dumps(manifest, sort_keys=True))
-                atomic_savez(out_path, **out, **{MANIFEST_KEY: manifest_arr})
-            finally:
-                _release_write_lock(lock_path)
+            # 重跑時 checkpoint.load_partial() 會讀回來跳過，不會白工。
+            # 存檔／跨行程競態保護見 scripts/tools/checkpoint.py 的
+            # save_progress()（原本這裡自己拿鎖、重讀磁碟、合併寫回的一段，
+            # 2026-08-20 收斂成共用函式，另外四支診斷腳本直接沿用）。
+            reps = checkpoint.save_progress(out_path, key, reps, manifest)
+            out[key] = np.array(reps)
         arr = out[key]
         if args.repeats > 1:
             print(f"{key} 跨 {args.repeats} 次：alpha 平均 {arr[:,3].mean():.3f}"

--- a/fit_real.py
+++ b/fit_real.py
@@ -385,7 +385,14 @@ def main():
         n_done = {k: len(v) for k, v in partial.items()}
         print(f"讀到既有部分結果 {out_path.name}：{n_done}"
               f"（會跳過已經算完的重複，不是從頭重算）\n", flush=True)
-    out = {k: list(v) for k, v in partial.items()}
+    # 截到 args.repeats：既有結果比這次要求的 --repeats 多時（例如磁碟
+    # 已有 3 次、這次只要 2 次），不截斷的話下面主迴圈會因為
+    # rep < len(reps) 全部跳過、out[key] 卻仍帶著全部 3 筆，讓「跨 2 次」
+    # 的平均/散布統計、還有 _preflight_gate() 的工作量報表都用了 3 筆，
+    # 跟這次實際要求的次數對不上（2026-08-20 CodeRabbit review）。只截
+    # 記憶體中這份拷貝，磁碟上的完整結果不動，也不影響「加大 --repeats」
+    # 的續傳能力（那是从磁碟重新 load_partial() 讀，不會被這裡截斷過）。
+    out = {k: list(v)[:args.repeats] for k, v in partial.items()}
     # **2026-08-20 改成無條件執行，不再只有 --preflight 才做**：這份檢查
     # 原本只在有人記得多打一個旗標時才會發生，但實際會呼叫這支腳本的
     # 地方不只 run_queue.py（那邊確實有記得先呼叫 --preflight）——Kaggle

--- a/fit_real.py
+++ b/fit_real.py
@@ -279,6 +279,14 @@ def main():
                          "且不砍觀測端，行為與加入這個旗標前完全相同。"
                          "用於等時線網格質量涵蓋不足時做同基準比較（D1）")
     args = ap.parse_args()
+    if args.repeats < 1:
+        # --repeats 0（或負數）讓 for rep in range(args.repeats) 完全不
+        # 執行，reps 停在空 list，np.array([]) 是 shape (0,) 的一維陣列。
+        # 沒有既有部分結果時，後面「alpha 隨模型設定的變化」總表對它做
+        # out[key][:, 3] 會丟 IndexError（2026-08-20 CodeRabbit review）。
+        # 這是結構性輸入錯誤，不是「已知風險、確認要略過」，--force 不
+        # 應該放行。
+        ap.error("--repeats must be positive")
     if args.repeat_offset < 0:
         ap.error("--repeat-offset must be non-negative")
     refines = [int(x) for x in args.refines.split(",") if x.strip()]

--- a/fit_real.py
+++ b/fit_real.py
@@ -363,6 +363,16 @@ def main():
     partial = checkpoint.load_partial(out_path)
     checkpoint.check_manifest(out_path, manifest, partial,
                               legacy_defaults=MANIFEST_LEGACY_DEFAULTS)
+    # `__attempted_*` 是 checkpoint.py 內部的記帳鍵（每個 config 存一份，
+    # 記「已嘗試次數」，供 inject_lowmass.py 這類會遇到貼牆例外的腳本
+    # 續傳時判斷哪些試驗不用重跑），不是這裡要的「設定名稱 -> 結果陣列」
+    # ——fit_real.py 一律成功、不需要那層區分，但 checkpoint.save_progress()
+    # 仍然統一會寫這個鍵。load_partial() 只排除 MANIFEST_KEY，不排除它，
+    # 混進 out 會讓下面 for key in out 的總表迴圈把它當成一個 config 去
+    # 取 [:,3]，丟 IndexError／KeyError（2026-08-20 CodeRabbit review 抓到：
+    # 續傳時才會觸發，第一次跑因為還沒有既有檔案不會發作）。跟
+    # preflight.gate_c() 用同一條 startswith("__") 排除規則。
+    partial = {k: v for k, v in partial.items() if not k.startswith("__")}
     if partial:
         n_done = {k: len(v) for k, v in partial.items()}
         print(f"讀到既有部分結果 {out_path.name}：{n_done}"
@@ -464,7 +474,15 @@ def main():
             # save_progress()（原本這裡自己拿鎖、重讀磁碟、合併寫回的一段，
             # 2026-08-20 收斂成共用函式，另外四支診斷腳本直接沿用）。
             reps = checkpoint.save_progress(out_path, key, reps, manifest)
-            out[key] = np.array(reps)
+        # 迴圈外無條件轉成 ndarray，不能只在迴圈內「有算新的一次」才轉
+        # ——若這個 key 的全部 repeats 都被續傳跳過（rep < len(reps) 對
+        # 每一次都成立），迴圈本體一次都不會執行，`out[key]` 會停在最初
+        # `out = {k: list(v) for k, v in partial.items()}` 那行給的原始
+        # list，下面 `arr[:,3]` 這種 ndarray 用法就會丟
+        # `TypeError: list indices must be integers or slices, not tuple`
+        # （這是既有 bug，續傳測試時發現，跟這次的 checkpoint 重構本身
+        # 無關但同一條路徑上，一併修掉）。
+        out[key] = np.array(reps)
         arr = out[key]
         if args.repeats > 1:
             print(f"{key} 跨 {args.repeats} 次：alpha 平均 {arr[:,3].mean():.3f}"

--- a/inject_lowmass.py
+++ b/inject_lowmass.py
@@ -45,30 +45,6 @@ P_TRUE_LIST = [0.9, 1.3, 1.7]
 P_MIN, P_MAX = 0.3, 2.3
 
 
-def atomic_savez(out_path: Path, **arrays):
-    """np.savez 不是原子操作——寫到一半被中斷（斷電、被砍行程）會留下
-    截斷或空的檔案，蓋掉前一次跑成功的 checkpoint（2026-08-13 CodeRabbit
-    review 指出：這支腳本每跑完一個 p_true 就存一次，是刻意設計成「前面
-    跑完的不該陪葬」，但直接 np.savez(out_path,...) 寫入中斷時反而會
-    毀掉這個保證本身）。改成寫到同目錄的暫存檔，成功才用 os.replace()
-    原子性地換過去；`os.replace()` 在 POSIX 與 Windows 都保證是單一
-    系統呼叫等級的原子操作，不會有「新檔案寫一半、舊檔案已經被砍」的
-    中間狀態。寫入中途失敗時清掉暫存檔，不留半成品在 results/ 底下。"""
-    # 檔名一定要用 .npz 結尾——np.savez() 對不是以 .npz 結尾的路徑會自動
-    # 補一個 .npz 副檔名（實測過：傳 "x.npz.tmp" 會真的寫成
-    # "x.npz.tmp.npz"），沒注意到這個行為的話 os.replace() 會找錯檔案。
-    tmp_path = out_path.with_name(out_path.stem + ".tmp.npz")
-    try:
-        np.savez(tmp_path, **arrays)
-        os.replace(tmp_path, out_path)
-    except BaseException:
-        try:
-            tmp_path.unlink()
-        except FileNotFoundError:
-            pass
-        raise
-
-
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--procs", type=int, default=None)
@@ -132,14 +108,38 @@ def main():
     cfg._data["joint_fit"]["mh_prior_sigma"] = 0.0
     base = joint_fit.JointModel(cfg, color, mag, grid, errmodel, dm)
 
+    # 2026-08-20：B3（續傳）—— 這支腳本原本每跑完一個 p_true 才存一次，
+    # 但重啟時不會讀回既有進度，一樣會重算已經跑完的 p_true。改用
+    # checkpoint.py，顆粒度細到「每一次試驗」（不是每個 p_true），且用
+    # attempted 計數區分「已嘗試」跟「已成功」——貼牆例外會跳過某次試驗
+    # 不計入結果，但那個試驗索引真的跑過一次，續傳時不該重跑
+    # （見 scripts/tools/checkpoint.py 的 load_progress() 說明）。
+    manifest = {"n_syn": args.n_syn, "refines": args.refines,
+                "dav_max": args.dav_max, "trial_offset": args.trial_offset,
+                "p_true_list": p_true_list}
     sys.path.insert(0, str(HERE / "scripts" / "tools"))
+    import checkpoint                                            # noqa: E402
     import preflight                                             # noqa: E402
+    partial = checkpoint.load_partial(out_path)
+    checkpoint.check_manifest(out_path, manifest, partial)
+
     if args.preflight:
         preflight._force_utf8_stdout()
+    scan_keys = [f"p{p}" for p in p_true_list]
+    partial_counts = {}
+    for p in p_true_list:
+        _, att = checkpoint.load_progress(partial, f"p{p}")
+        partial_counts[f"p{p}"] = att
+    w_fails, w_warns = preflight.workload_audit(
+        scan_keys=scan_keys, repeats=args.trials, n_syn=args.n_syn,
+        n_obs=n_obs, refines=refines, partial_counts=partial_counts,
+        unit="次試驗", scan_label="注入真值（P_TRUE_LIST／--only）")
+    preflight.output_audit(out_path, partial)
     preflight.mandatory_gate(
         base, grid, refines, script="inject_lowmass.py",
         expected_overrides={"mh_prior_sigma": 0.0},
-        force=args.force, dry_run=args.preflight)
+        force=args.force, dry_run=args.preflight,
+        extra_fails=w_fails, extra_warns=w_warns)
 
     sel = selmod.load(HERE / "data" / "selection.npz")
 
@@ -177,8 +177,14 @@ def main():
     results = {}
 
     for p_true in p_true_list:
-        outs = []
+        key = f"p{p_true}"
+        outs, attempted = checkpoint.load_progress(partial, key)
         for t in range(args.trials):
+            if t < attempted:
+                print(f"  p_true={p_true:.1f} trial{t+1}：已嘗試過，跳過"
+                      f"（不管當時成功或失敗，重跑只會用同一組亂數種子"
+                      f"再得到同一個結果）", flush=True)
+                continue
             # 生成假資料：注入指定的低質量段冪次
             gen = base.with_observations(color, mag)
             gen.selection = sel
@@ -215,12 +221,20 @@ def main():
                       f"不影響其餘試驗）：{type(e).__name__}: "
                       f"{str(e).splitlines()[1] if len(str(e).splitlines()) > 1 else e}",
                       flush=True)
+                attempted = t + 1
+                outs = checkpoint.save_progress(out_path, key, outs, manifest,
+                                                attempted=attempted)
                 continue
             outs.append(best)
+            attempted = t + 1
             print(f"  p_true={p_true:.1f} trial{t+1}  "
                   f"p_rec={best[7]:.3f}  alpha={best[3]:.3f}  "
                   f"dav={best[6]:.3f}  lnP={lp:.1f}  "
                   f"({time.time()-t0:.0f}s)", flush=True)
+            # 跑完一次試驗就存一次（不管成功或失敗），不等這個 p_true 的
+            # 全部 trials 都跑完——中途被砍，已經算完的每一次試驗都保得住。
+            outs = checkpoint.save_progress(out_path, key, outs, manifest,
+                                            attempted=attempted)
         if not outs:
             print(f"  p_true={p_true:.1f} 全部 {args.trials} 次試驗都失敗，"
                   "略過（見上方各次的失敗原因）", flush=True)
@@ -229,11 +243,12 @@ def main():
             print(f"  p_true={p_true:.1f}：{len(outs)}/{args.trials} 次成功，"
                   "其餘見上方失敗紀錄", flush=True)
         results[p_true] = np.array(outs)
-        # 每跑完一個 p_true 就存一次 —— 之後的 p_true 若整批失敗，
-        # 這裡已經算出來的結果不會跟著陪葬。
-        atomic_savez(out_path,
-                     p_true=np.array(list(results.keys())),
-                     **{f"p{p}": v for p, v in results.items()})
+        # 補記 p_true 摘要陣列（試驗層級的存檔在上面迴圈已經逐次做了，
+        # 這裡只是把「目前有哪些 p_true 已經有成功結果」這個摘要寫回去，
+        # 跟原本「每跑完一個 p_true 就存一次」同一個顆粒度）。
+        outs = checkpoint.save_progress(
+            out_path, key, outs, manifest, attempted=attempted,
+            extra_arrays={"p_true": np.array(list(results.keys()))})
 
     print(f"\n{'='*70}")
     print("identifiability of low-mass slope")
@@ -255,9 +270,8 @@ def main():
     if len(p_recs) < 2:
         print("\n少於兩個 p_true 有成功資料，無法判斷可辨識性（條件 3 需要"
               "跨多個真值比較），僅供參考個別數字。")
-        atomic_savez(out_path,
-                     p_true=np.array(list(results.keys())),
-                     **{f"p{p}": v for p, v in results.items()})
+        # 每一次試驗跑完就已經存過檔了（見上面迴圈裡的
+        # checkpoint.save_progress()），這裡不用再存一次。
         return
 
     p_recs = np.array(p_recs)
@@ -273,9 +287,8 @@ def main():
     print("  ratio near 1 = identifiable; near 0 = unconstrained "
           "(recovers same value regardless of truth)")
 
-    atomic_savez(out_path,
-                 p_true=np.array(p_true_ok),
-                 **{f"p{p}": v for p, v in results.items()})
+    # 每一次試驗跑完就已經存過檔了（見上面迴圈裡的
+    # checkpoint.save_progress()），這裡不用再存一次，只是印出最終確認訊息。
     print(f"\nwrote {out_path.relative_to(HERE)}")
 
 

--- a/inject_lowmass.py
+++ b/inject_lowmass.py
@@ -57,7 +57,8 @@ def main():
                          "3 個帳號各跑一次時，是各自下 --trials 1 --trial-offset 0 / "
                          "1 / 2 三道獨立指令。**每個分片必須配一個唯一的 --tag**"
                          "（例如 _p6b_v2_t0 / _t1 / _t2）——輸出路徑只由 --tag 決定，"
-                         "共用同一個 --tag 的分片會互相覆寫，atomic_savez() 不會幫忙"
+                         "共用同一個 --tag 的分片會互相覆寫，"
+                         "scripts/tools/checkpoint.py 的存檔機制不會幫忙"
                          "合併。全部跑完後把各檔案依 offset 由小到大沿 axis=0 串接，"
                          "即等於一次跑完。預設 0，不影響既有行為（比照 fit_real.py 的"
                          "--repeat-offset，見 PR #55）")

--- a/injection_recovery.py
+++ b/injection_recovery.py
@@ -342,7 +342,41 @@ def main():
                  "避免覆寫 results/injection_recovery.npz（A1 統計誤差 "
                  "0.144 的來源檔案，見 LIMITATIONS.md D6 記錄過的同類事故）")
     n_proc = args.procs or (os.cpu_count() or 1)
+    out_path = HERE / "results" / f"injection_recovery{args.tag}.npz"
+
+    # **B1（意圖對帳）要用的「已知情境名稱」必須在這裡（模型建構之前）就
+    # 算出來**：dav_sweep／extra_scatter_sweep 兩個旗標會動態追加
+    # S2@<v>／S1var@<v> 這種情境名稱，原本這段邏輯（連同 want 的更新）
+    # 寫在 SCEN 字典旁邊，比模型建構晚很多——但 preflight 的 gate 要在
+    # 建好模型後、真正開始擬合前就跑，所以「這次到底會處理哪些情境」
+    # 必須先算好。SCEN 字典本體（含每個情境的實際定義）仍留在原本位置
+    # 建構，因為它需要 sel（選擇函數，稍後才載入）；這裡只需要「名稱」。
     want = [s.strip().upper() for s in args.scenarios.split(",")]
+    known_scenarios = {"S1", "S2", "S3", "S3F", "S4"}
+    var_inject = {}
+    if args.dav_sweep:
+        dav_sweep_vals = [float(x) for x in args.dav_sweep.split(",")]
+        want = [k for k in want if k != "S2"] \
+            + [f"S2@{v:g}" for v in dav_sweep_vals]
+        known_scenarios |= {f"S2@{v:g}" for v in dav_sweep_vals}
+    if args.extra_scatter_sweep:
+        scatter_vals = [float(x) for x in args.extra_scatter_sweep.split(",")]
+        want = want + [f"S1var@{v:g}" for v in scatter_vals]
+        for v in scatter_vals:
+            key = f"S1var@{v:g}"
+            known_scenarios.add(key)
+            var_inject[key] = v
+    # 原本這裡是 `if key not in SCEN: print("未知情境", key, "，略過")`——
+    # 靜默略過，preflight 通過、擬合照跑，但實際處理的情境跟意圖不同，
+    # 是跟 fit_real.py 打錯 --configs 名稱一模一樣的錯誤形狀（見 main()
+    # 下方那道不能被 --force 繞過的硬阻擋，跟 workload_audit 那道可以
+    # 被 --force 繞過的阻擋，兩者都要有，理由同 fit_real.py 的註解）。
+    unknown_scenarios = [k for k in want if k not in known_scenarios]
+
+    def _store_key(k: str) -> str:
+        """情境名稱轉成存檔用的鍵——`@`／`.` 不是合法的 npz 鍵字元，跟
+        main() 最後寫檔時原本用的轉換規則一致（S2@0.3 -> S2_at_0p3）。"""
+        return k.replace("@", "_at_").replace(".", "p")
 
     cfg = cfgmod.load()
     c3, cj = cfg.step3_age, cfg.joint_fit
@@ -356,7 +390,8 @@ def main():
     ok = np.isfinite(color) & np.isfinite(mag)
     n_obs = int(ok.sum())
 
-    cfg._data["step3_age"]["n_synthetic"] = args.n_syn or cj.n_synthetic
+    effective_n_syn = args.n_syn or cj.n_synthetic
+    cfg._data["step3_age"]["n_synthetic"] = effective_n_syn
     cfg._data["joint_fit"]["mh_prior_sigma"] = 0.0   # 測流程本身，關掉先驗
 
     base = joint_fit.JointModel(cfg, color[ok], mag[ok], grid, errmodel, dm)
@@ -372,14 +407,43 @@ def main():
         print(f"擬合模型的共用亂數改用種子 {args.model_seed}")
     refines = [int(x) for x in args.refines.split(",") if x.strip()]
 
+    # 2026-08-20：B3（續傳）—— 這支腳本原本完全沒有續傳機制，只在全部
+    # 情境跑完後 np.savez 一次，中途被砍就整批白工。改用 checkpoint.py，
+    # 顆粒度到「每個情境的每一次試驗」。這支腳本的 multi_stage_best() 呼叫
+    # 帶 raise_on_wall=False（貼牆只印警告、不丟例外），跟 inject_lowmass.py
+    # 不同，不需要 attempted 計數區分「已嘗試」跟「已成功」——每次嘗試
+    # 必定成功，跟 profile_lowmass.py 同一種情況。
+    manifest = {"n_syn": effective_n_syn, "refines": args.refines,
+                "dav_true": args.dav_true, "model_seed": args.model_seed,
+                "dav_distribution": args.dav_distribution}
     sys.path.insert(0, str(HERE / "scripts" / "tools"))
+    import checkpoint                                            # noqa: E402
     import preflight                                             # noqa: E402
+    partial = checkpoint.load_partial(out_path)
+    checkpoint.check_manifest(out_path, manifest, partial)
+
     if args.preflight:
         preflight._force_utf8_stdout()
+    scan_keys = [k for k in want if k in known_scenarios]
+    partial_counts = {k: len(partial.get(_store_key(k), [])) for k in scan_keys}
+    w_fails, w_warns = preflight.workload_audit(
+        scan_keys=scan_keys, repeats=args.trials, n_syn=effective_n_syn,
+        n_obs=n_obs, refines=refines, partial_counts=partial_counts,
+        unit="次試驗", unknown=unknown_scenarios,
+        known=sorted(known_scenarios), scan_label="情境（--scenarios）")
+    preflight.output_audit(out_path, partial)
     preflight.mandatory_gate(
         base, grid, refines, script="injection_recovery.py",
         expected_overrides={"mh_prior_sigma": 0.0},
-        force=args.force, dry_run=args.preflight)
+        force=args.force, dry_run=args.preflight,
+        extra_fails=w_fails, extra_warns=w_warns)
+    # 打錯的情境名稱要當場中止，不能像下面迴圈那樣靜默略過——理由跟
+    # fit_real.py 對 --configs 的處理完全一樣（見該檔案 main() 裡的
+    # 註解）：workload_audit 那道阻擋可以被 --force 繞過，這裡不行。
+    if unknown_scenarios:
+        print(f"錯誤：--scenarios 有不存在的情境名稱 {unknown_scenarios}"
+              f"（可用：{', '.join(sorted(known_scenarios))}）", flush=True)
+        sys.exit(1)
 
     sel = selmod.load(HERE / "data" / "selection.npz")
     npt = int(np.prod([len(a) for a in COARSE]))
@@ -407,38 +471,41 @@ def main():
                args.dav_true, None, 0.0, None, np.arange(0.0, 1.21, 0.20)),
     }
 
-    # dav 掃描：把 S2 換成一系列不同注入值的情境
+    # dav 掃描：把 S2 換成一系列不同注入值的情境。`want` 的更新（S2 換成
+    # S2@<v> 一系列）已經在檔案上面（模型建構之前，preflight 需要用到
+    # 完整的 want 清單）做過一次，這裡只需要把對應的 SCEN 定義補上。
     if args.dav_sweep:
-        vals = [float(x) for x in args.dav_sweep.split(",")]
-        for v in vals:
+        for v in dav_sweep_vals:
             SCEN[f"S2@{v:g}"] = (f"漏掉差異消光（注入 dav={v:g}，擬合當作 0）",
                                  v, None, 0.0, None, None)
-        want = [k for k in want if k != "S2"] + [f"S2@{v:g}" for v in vals]
 
     # C19 額外亮度散布掃描：情境本身跟 S1 對照組完全一樣（有選擇函數、
     # 有差異消光），唯一差別是假資料多帶一個未被模型描述的亮度散布。
-    # 用一個獨立的 dict 記「這個情境要注入多少散布」，而不是擴充 SCEN
-    # 的 tuple——SCEN 的六元組在下面迴圈裡被拆解使用，多加一個欄位要
-    # 動到所有既有情境，改動面大且容易出錯。
-    var_inject = {}
+    # `var_inject`（「這個情境要注入多少散布」）跟 `want` 的更新同樣已經
+    # 在檔案上面做過，這裡只補 SCEN 定義——不擴充 SCEN 的六元組本身，
+    # 那個元組在下面迴圈裡被拆解使用，多加一個欄位要動到所有既有情境，
+    # 改動面大且容易出錯。
     if args.extra_scatter_sweep:
-        vals = [float(x) for x in args.extra_scatter_sweep.split(",")]
-        for v in vals:
-            key = f"S1var@{v:g}"
-            SCEN[key] = (f"額外亮度散布 {v:g} mag（模型沒有這一項，C19）",
-                         0.0, None, 0.0, None, None)
-            var_inject[key] = v
-        want = want + [f"S1var@{v:g}" for v in vals]
+        for v in scatter_vals:
+            SCEN[f"S1var@{v:g}"] = (f"額外亮度散布 {v:g} mag（模型沒有這一項，C19）",
+                                    0.0, None, 0.0, None, None)
 
     results = {}
     for key in want:
         if key not in SCEN:
+            # 走到這裡代表用了 --force 略過上面的硬阻擋；仍然略過，不要
+            # 假裝算過這個情境。
             print(f"未知情境 {key}，略過")
             continue
+        skey = _store_key(key)
         desc, dav_in, sel_in, dav_fit, sel_fit, extra = SCEN[key]
         print(f"\n{'='*74}\n{key}：{desc}\n{'='*74}")
-        got_all = []
+        got_all = list(partial.get(skey, []))
         for t in range(args.trials):
+            if t < len(got_all):
+                print(f"  {key} 第 {t+1} 次：沿用既有結果，跳過重算",
+                      flush=True)
+                continue
             t0 = time.time()
             # C19：只有生成端帶額外亮度散布，擬合端一律 0——這正是要測的
             # 「模型沒有這一項」的情境。用 try/finally 還原，避免某次試驗
@@ -457,7 +524,9 @@ def main():
                 m.enable_dav_fit(float(extra.min()), float(extra.max()))
             # dav（索引 6）已由注入回收證實不可辨識，貼牆是預期行為；
             # 其餘維度貼牆會印出警告（診斷用的跑法不中止，
-            # 產出科學數字的 fit_real.py 則設成直接報錯）。
+            # 產出科學數字的 fit_real.py 則設成直接報錯）。raise_on_wall=
+            # False 代表這裡不會丟例外，每次嘗試必定成功，不需要像
+            # inject_lowmass.py 那樣另外追蹤「已嘗試」跟「已成功」的差別。
             best, lp, bounds = multi_stage_best(
                 m, COARSE, refines, n_proc, extra_axis=extra,
                 allow_wall=(6,) if extra is not None else (),
@@ -467,6 +536,12 @@ def main():
             report(f"{key} 第 {t+1} 次  lnP={lp:.1f}", truth, best, bounds,
                    time.time() - t0)
             got_all.append(best)
+            # 跑完一次試驗就存一次，不等這個情境或全部情境都跑完——
+            # 中途被砍，已經算完的每一次試驗都保得住，重跑時讀回來跳過。
+            got_all = checkpoint.save_progress(
+                out_path, skey, got_all, manifest,
+                extra_arrays={"theta_true": THETA_TRUE,
+                             "dav_distribution": args.dav_distribution})
         got_all = np.array(got_all)
         results[key] = got_all
         if len(got_all) > 1:
@@ -496,16 +571,10 @@ def main():
         print("      代表 +0.178 只是曲線在 dav=0.30 這一點的值，")
         print("      與選擇函數的 -0.178 相等純屬巧合（因為 0.30 是我挑的）。")
 
-    out_path = HERE / "results" / f"injection_recovery{args.tag}.npz"
-    # dav_distribution 一起存進檔案（2026-08-19 CodeRabbit PR #63）：
-    # 它會改變假資料的生成方式，兩種分布跑出來的結果不可互比，但檔名只由
-    # --tag 決定。不存的話，事後拿到 npz 無從判斷這批是 lognormal 還是
-    # trunc_exp 算的——C5 這個比較的重點正是兩者的差，認錯來源就整個作廢。
-    np.savez(out_path,
-             theta_true=THETA_TRUE,
-             dav_distribution=args.dav_distribution,
-             **{k.replace("@", "_at_").replace(".", "p"): v
-                for k, v in results.items()})
+    # 每一次試驗跑完就已經存過檔了（見上面迴圈裡的
+    # checkpoint.save_progress()，含 theta_true／dav_distribution 這兩個
+    # metadata——2026-08-19 CodeRabbit PR #63 要求存的欄位，現在每次存檔
+    # 都會寫，不用等到最後），這裡不用再存一次，只是印出最終確認訊息。
     print(f"\n寫入 {out_path}")
 
 

--- a/profile_lowmass.py
+++ b/profile_lowmass.py
@@ -138,7 +138,14 @@ def main():
     results = {}
     for p in slopes:
         key = f"p{p}"
-        outs = list(partial.get(key, []))
+        # 截到 args.repeats：既有結果比這次要求的 --repeats 多時（例如
+        # 磁碟上已有 3 次、這次只要 2 次），不截斷的話下面的迴圈會因為
+        # rep < len(outs) 全部跳過、outs 卻仍帶著全部 3 筆，讓「跨 2 次」
+        # 的平均/散布統計實際上是用 3 筆算出來的，跟印出來的次數對不上
+        # （2026-08-20 CodeRabbit review）。不把 repeats 放進 manifest 就是
+        # 為了讓「加大 --repeats」保持可續傳，這裡只是不讓「縮小
+        # --repeats」意外地用了太多筆。
+        outs = list(partial.get(key, []))[:args.repeats]
         for rep in range(args.repeats):
             if rep < len(outs):
                 print(f"  p={p:.1f} 第{rep+1}次：沿用既有結果，跳過重算",

--- a/profile_lowmass.py
+++ b/profile_lowmass.py
@@ -67,6 +67,12 @@ def main():
     ap.add_argument("--force", action="store_true",
                     help="略過開跑前檢查的阻擋（不建議，僅供已知情況使用）")
     args = ap.parse_args()
+    if args.repeats < 1:
+        # --repeats 0（或負數）會讓 outs 被截成空 list（見下面
+        # [:args.repeats] 那行），np.array([]) 是 shape (0,) 的一維陣列，
+        # 後面 arr[:, 3] 直接丟 IndexError；且這段沒有被 --force 保護的
+        # 條件包住，屬於結構性輸入錯誤（2026-08-20 CodeRabbit review）。
+        ap.error("--repeats must be positive")
     n_proc = args.procs or (os.cpu_count() or 1)
     refines = [int(x) for x in args.refines.split(",") if x.strip()]
     slopes = ([float(x) for x in args.slopes.split(",")] if args.slopes

--- a/profile_lowmass.py
+++ b/profile_lowmass.py
@@ -89,18 +89,37 @@ def main():
     cfg._data["joint_fit"]["mh_prior_sigma"] = 0.0
     base = joint_fit.JointModel(cfg, color, mag, grid, errmodel, dm)
 
+    # 2026-08-20：B3（續傳）—— 這支腳本原本只在全部掃描點跑完後 np.savez
+    # 一次，中途被砍（p6_lowmass_v2 案例：本機四天內被 Windows 強制重開機
+    # 四次）就得從頭重算，即使前面已經跑完的冪次本身沒有問題。改用
+    # scripts/tools/checkpoint.py 的共用續傳機制，跟 fit_real.py 同一套。
+    out_path = HERE / "results" / "profile_lowmass.npz"
+    manifest = {"n_syn": args.n_syn, "refines": args.refines,
+                "dav_max": args.dav_max, "slopes": slopes}
+    sys.path.insert(0, str(HERE / "scripts" / "tools"))
+    import checkpoint                                            # noqa: E402
+    import preflight                                             # noqa: E402
+    partial = checkpoint.load_partial(out_path)
+    checkpoint.check_manifest(out_path, manifest, partial)
+
     # 開跑前檢查——無條件執行，不是選用步驟（見 scripts/tools/
     # preflight.py 的 mandatory_gate() 說明）。mh_prior_sigma=0.0 是這支
     # 腳本刻意的行為（先驗會污染要測的低質量段冪次敏感度），登記進
     # expected_overrides 避免每次都誤報成阻擋。
-    sys.path.insert(0, str(HERE / "scripts" / "tools"))
-    import preflight                                             # noqa: E402
     if args.preflight:
         preflight._force_utf8_stdout()
+    scan_keys = [f"p{p}" for p in slopes]
+    partial_counts = {k: len(partial.get(k, [])) for k in scan_keys}
+    w_fails, w_warns = preflight.workload_audit(
+        scan_keys=scan_keys, repeats=args.repeats, n_syn=args.n_syn,
+        n_obs=n_obs, refines=refines, partial_counts=partial_counts,
+        unit="次重複", scan_label="低質量段冪次（--slopes）")
+    preflight.output_audit(out_path, partial)
     preflight.mandatory_gate(
         base, grid, refines, script="profile_lowmass.py",
         expected_overrides={"mh_prior_sigma": 0.0},
-        force=args.force, dry_run=args.preflight)
+        force=args.force, dry_run=args.preflight,
+        extra_fails=w_fails, extra_warns=w_warns)
 
     sel = selmod.load(HERE / "data" / "selection.npz")
     print(f"真實觀測 {n_obs:,} 顆，config C（選擇函數 + 差異消光），"
@@ -110,8 +129,13 @@ def main():
     from pipeline.step3_age import draw_randoms
     results = {}
     for p in slopes:
-        outs = []
+        key = f"p{p}"
+        outs = list(partial.get(key, []))
         for rep in range(args.repeats):
+            if rep < len(outs):
+                print(f"  p={p:.1f} 第{rep+1}次：沿用既有結果，跳過重算",
+                      flush=True)
+                continue
             import copy
             m = copy.copy(base)
             m.obs_h = joint_fit.hess(color, mag, base.nb_c, base.nb_m,
@@ -137,6 +161,11 @@ def main():
             print(f"  p={p:.1f} 第{rep+1}次  alpha={best[3]:.3f}  "
                   f"A_V={best[1]:.3f}  logage={best[0]:.3f}  "
                   f"lnP={lp:.1f}  ({time.time()-t0:.0f}s)", flush=True)
+            # 跑完一次重複就存一次，不等全部冪次或全部重複都跑完——中途
+            # 被砍，已經算完的每一次重複都保得住，重跑時讀回來跳過。
+            outs = checkpoint.save_progress(
+                out_path, key, outs, manifest,
+                extra_arrays={"slopes": np.array(slopes)})
         arr = np.array(outs)
         results[p] = arr
         print(f"  -> p={p:.1f} 跨 {args.repeats} 次：alpha 平均 "
@@ -159,10 +188,9 @@ def main():
     print("      必須升格為自由參數或至少在論文列為系統誤差項；")
     print("      倍數接近或小於 1，代表目前的固定值不是主要誤差來源。")
 
-    np.savez(HERE / "results" / "profile_lowmass.npz",
-             slopes=np.array(slopes),
-             **{f"p{p}": v for p, v in results.items()})
-    print("\n寫入 results/profile_lowmass.npz")
+    # 每一次重複跑完就已經存過檔了（見上面迴圈裡的 checkpoint.save_progress()），
+    # 這裡不用再存一次，只是印出最終確認訊息。
+    print(f"\n已寫入 {out_path.relative_to(HERE)}")
 
 
 if __name__ == "__main__":

--- a/profile_lowmass.py
+++ b/profile_lowmass.py
@@ -94,8 +94,16 @@ def main():
     # 四次）就得從頭重算，即使前面已經跑完的冪次本身沒有問題。改用
     # scripts/tools/checkpoint.py 的共用續傳機制，跟 fit_real.py 同一套。
     out_path = HERE / "results" / "profile_lowmass.npz"
+    # slopes 不放進 manifest：這支腳本沒有 --tag（輸出檔名固定），若把
+    # 掃描點清單也拿去比對，擴大 --slopes 範圍就會被 check_manifest()
+    # 判定成「設定不同」而 sys.exit(1)，錯誤訊息還會叫使用者「換一個
+    # --tag」——但這支腳本根本沒有這個旗標，使用者只能手動刪掉整個
+    # 既有結果檔，前面已經跑完的掃描點全部作廢。每個掃描點各自有獨立
+    # 的 scan_key（f"p{p}"），互不污染，不需要靠 manifest 擋這個
+    # （2026-08-20 CodeRabbit review）。slopes 本身仍會透過下面迴圈裡
+    # 的 extra_arrays 存進輸出檔，事後查得到這批掃過哪些點。
     manifest = {"n_syn": args.n_syn, "refines": args.refines,
-                "dav_max": args.dav_max, "slopes": slopes}
+                "dav_max": args.dav_max}
     sys.path.insert(0, str(HERE / "scripts" / "tools"))
     import checkpoint                                            # noqa: E402
     import preflight                                             # noqa: E402

--- a/profile_outlierfrac.py
+++ b/profile_outlierfrac.py
@@ -84,8 +84,13 @@ def main():
     # 2026-08-20：B3（續傳）—— 同 profile_lowmass.py，原本只在全部掃描點
     # 跑完後 np.savez 一次，中途被砍就得從頭重算。改用 checkpoint.py。
     out_path = HERE / "results" / "profile_outlierfrac.npz"
+    # fracs 不放進 manifest——同 profile_lowmass.py 的理由（這支腳本也
+    # 沒有 --tag，把掃描點清單放進 manifest 會讓擴大 --fracs 範圍時被
+    # check_manifest() 擋下，還叫使用者去用一個不存在的旗標；每個掃描點
+    # 各自有獨立的 scan_key，不需要 manifest 擋，2026-08-20 CodeRabbit
+    # review）。fracs 仍透過下面迴圈的 extra_arrays 存進輸出檔。
     manifest = {"n_syn": args.n_syn, "refines": args.refines,
-                "dav_max": args.dav_max, "fracs": fracs}
+                "dav_max": args.dav_max}
     sys.path.insert(0, str(HERE / "scripts" / "tools"))
     import checkpoint                                            # noqa: E402
     import preflight                                             # noqa: E402

--- a/profile_outlierfrac.py
+++ b/profile_outlierfrac.py
@@ -81,14 +81,31 @@ def main():
     cfg._data["joint_fit"]["mh_prior_sigma"] = 0.0
     base = joint_fit.JointModel(cfg, color, mag, grid, errmodel, dm)
 
+    # 2026-08-20：B3（續傳）—— 同 profile_lowmass.py，原本只在全部掃描點
+    # 跑完後 np.savez 一次，中途被砍就得從頭重算。改用 checkpoint.py。
+    out_path = HERE / "results" / "profile_outlierfrac.npz"
+    manifest = {"n_syn": args.n_syn, "refines": args.refines,
+                "dav_max": args.dav_max, "fracs": fracs}
     sys.path.insert(0, str(HERE / "scripts" / "tools"))
+    import checkpoint                                            # noqa: E402
     import preflight                                             # noqa: E402
+    partial = checkpoint.load_partial(out_path)
+    checkpoint.check_manifest(out_path, manifest, partial)
+
     if args.preflight:
         preflight._force_utf8_stdout()
+    scan_keys = [f"f{frac}" for frac in fracs]
+    partial_counts = {k: len(partial.get(k, [])) for k in scan_keys}
+    w_fails, w_warns = preflight.workload_audit(
+        scan_keys=scan_keys, repeats=args.repeats, n_syn=args.n_syn,
+        n_obs=n_obs, refines=refines, partial_counts=partial_counts,
+        unit="次重複", scan_label="殘留場星污染比例（--fracs）")
+    preflight.output_audit(out_path, partial)
     preflight.mandatory_gate(
         base, grid, refines, script="profile_outlierfrac.py",
         expected_overrides={"mh_prior_sigma": 0.0},
-        force=args.force, dry_run=args.preflight)
+        force=args.force, dry_run=args.preflight,
+        extra_fails=w_fails, extra_warns=w_warns)
 
     sel = selmod.load(HERE / "data" / "selection.npz")
     print(f"真實觀測 {n_obs:,} 顆，config C（選擇函數 + 差異消光），"
@@ -98,8 +115,13 @@ def main():
     from pipeline.step3_age import draw_randoms
     results = {}
     for frac in fracs:
-        outs = []
+        key = f"f{frac}"
+        outs = list(partial.get(key, []))
         for rep in range(args.repeats):
+            if rep < len(outs):
+                print(f"  frac={frac:.3f} 第{rep+1}次：沿用既有結果，跳過重算",
+                      flush=True)
+                continue
             import copy
             m = copy.copy(base)
             m.obs_h = joint_fit.hess(color, mag, base.nb_c, base.nb_m,
@@ -125,6 +147,9 @@ def main():
             print(f"  frac={frac:.3f} 第{rep+1}次  alpha={best[3]:.3f}  "
                   f"A_V={best[1]:.3f}  logage={best[0]:.3f}  "
                   f"lnP={lp:.1f}  ({time.time()-t0:.0f}s)", flush=True)
+            outs = checkpoint.save_progress(
+                out_path, key, outs, manifest,
+                extra_arrays={"fracs": np.array(fracs)})
         arr = np.array(outs)
         results[frac] = arr
         print(f"  -> frac={frac:.3f} 跨 {args.repeats} 次：alpha 平均 "
@@ -147,10 +172,9 @@ def main():
     print("      倍數接近或小於 1，代表目前固定 0.01 不是主要誤差來源，")
     print("      LIMITATIONS.md 裡「現役假設」的標記可以降級為「已驗證安全」。")
 
-    np.savez(HERE / "results" / "profile_outlierfrac.npz",
-             fracs=np.array(fracs),
-             **{f"f{frac}": v for frac, v in results.items()})
-    print("\n寫入 results/profile_outlierfrac.npz")
+    # 每一次重複跑完就已經存過檔了（見上面迴圈裡的 checkpoint.save_progress()），
+    # 這裡不用再存一次，只是印出最終確認訊息。
+    print(f"\n已寫入 {out_path.relative_to(HERE)}")
 
 
 if __name__ == "__main__":

--- a/profile_outlierfrac.py
+++ b/profile_outlierfrac.py
@@ -59,6 +59,11 @@ def main():
     ap.add_argument("--force", action="store_true",
                     help="略過開跑前檢查的阻擋（不建議，僅供已知情況使用）")
     args = ap.parse_args()
+    if args.repeats < 1:
+        # 理由同 profile_lowmass.py 的同一處檢查（2026-08-20 CodeRabbit
+        # review）：--repeats 0（或負數）會讓 outs 截成空 list，後面
+        # arr[:, 3] 丟 IndexError，且沒有被 --force 保護。
+        ap.error("--repeats must be positive")
     n_proc = args.procs or (os.cpu_count() or 1)
     refines = [int(x) for x in args.refines.split(",") if x.strip()]
     fracs = ([float(x) for x in args.fracs.split(",")] if args.fracs

--- a/profile_outlierfrac.py
+++ b/profile_outlierfrac.py
@@ -121,7 +121,10 @@ def main():
     results = {}
     for frac in fracs:
         key = f"f{frac}"
-        outs = list(partial.get(key, []))
+        # 截到 args.repeats：理由同 profile_lowmass.py 的同一處修正
+        # （2026-08-20 CodeRabbit review）——既有結果比這次要求的
+        # --repeats 多時，不截斷會讓統計筆數跟印出來的次數對不上。
+        outs = list(partial.get(key, []))[:args.repeats]
         for rep in range(args.repeats):
             if rep < len(outs):
                 print(f"  frac={frac:.3f} 第{rep+1}次：沿用既有結果，跳過重算",

--- a/scripts/tools/checkpoint.py
+++ b/scripts/tools/checkpoint.py
@@ -1,0 +1,267 @@
+# -*- coding: utf-8 -*-
+"""續傳／存檔共用邏輯（B3，見 docs/reference/PREFLIGHT.md）。
+
+**這裡解決的問題跟 preflight.py 不同**：preflight.py 防的是「設定錯了
+沒人發現」，這裡防的是「設定對，但中途被砍（斷電、重開機、手動中止）
+就要從頭重算」——兩者互不重疊，一套完整的保護兩個都要有。
+
+**動機**：`fit_real.py` 從 2026-08-15 起就有這套續傳機制（見 PR #55 起的
+一系列修正），但另外四支診斷腳本（`profile_lowmass.py`／
+`profile_outlierfrac.py`／`inject_lowmass.py`／`injection_recovery.py`）
+要嘛完全沒有（只在最後 `np.savez` 一次），要嘛只做到一半
+（`inject_lowmass.py` 每跑完一個注入真值存一次，但重啟時不會讀回既有
+進度，一樣會重算已經跑完的部分）。本機曾經因為 Windows 連續四天強制
+重開機四次，讓沒有續傳保護的 `profile_lowmass.py` 空轉四天一次都沒
+跑完（`p6_lowmass_v2`），是這套機制存在的直接理由。
+
+抽成共用模組而不是讓五支腳本各寫一份的理由跟 `preflight.audit_common()`
+完全一樣：`fit_real.py` 原本自己維護一份 A1/A2/A3，`preflight.py` 建好
+共用版本後有一次沒改到 `fit_real.py` 自己那份，兩份不同步了一輪才發現。
+續傳邏輯一旦分裂成五份，同樣的事只是換個地方重演。
+
+**用法**（兩種腳本都適用）：
+
+    manifest = {"n_syn": args.n_syn, "refines": args.refines, ...}
+    partial = checkpoint.load_partial(out_path)
+    checkpoint.check_manifest(out_path, manifest, partial)
+
+    for scan_val in scan_points:
+        key = f"p{scan_val}"
+        results, attempted = checkpoint.load_progress(partial, key)
+        for t in range(n_repeats):
+            if t < attempted:
+                continue                       # 已經跑過（不管成功與否）
+            ... 算一次 ...
+            if 失敗:
+                attempted = t + 1
+                results = checkpoint.save_progress(
+                    out_path, key, results, manifest, attempted=attempted)
+                continue
+            results.append(best)
+            attempted = t + 1
+            results = checkpoint.save_progress(
+                out_path, key, results, manifest, attempted=attempted)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+# 存在輸出 npz 裡的保留鍵，記錄「這批部分結果是用什麼設定算出來的」。
+# 用雙底線包住避免跟 scan_key（設定名稱／掃描值字串化後的鍵）撞名。
+MANIFEST_KEY = "__manifest__"
+
+
+def atomic_savez(out_path: Path, **arrays) -> None:
+    """np.savez 不是原子操作——寫到一半被中斷（斷電、被砍行程）會留下
+    截斷或空的檔案，蓋掉前一次跑成功的 checkpoint。改成寫到同目錄的
+    暫存檔，成功才用 os.replace() 原子性地換過去；`os.replace()` 在
+    POSIX 與 Windows 都保證是單一系統呼叫等級的原子操作，不會有
+    「新檔案寫一半、舊檔案已經被砍」的中間狀態。寫入中途失敗時清掉
+    暫存檔，不留半成品在 results/ 底下。
+
+    （原本 fit_real.py 與 inject_lowmass.py 各自有一份幾乎逐字相同的
+    實作，2026-08-20 收斂成這一份共用版本。）
+
+    **`os.replace()` 在 Windows 上偶發 `PermissionError: [WinError 5]`**：
+    自動化測試裡用高速迴圈連續存檔時重現過（同一組程式碼三次裡有一次
+    炸掉，另外兩次正常）——不是邏輯錯誤，是 Windows 上防毒軟體即時掃描
+    或索引服務短暫佔用剛寫完的暫存檔，`os.replace()` 撞上那個窗口就會
+    被拒絕，過幾十毫秒鎖就放開了。這跟 `acquire_write_lock()`
+    對付另一個行程持有鎖檔是同一類「等一下再試」的問題，這裡比照辦理：
+    對 `PermissionError` 做有上限的重試，不是無限期忽略錯誤——重試次數
+    用完仍然失敗就真的往上拋，不會把持續性的權限問題（例如檔案真的被
+    唯讀鎖定）吞掉裝作沒事。"""
+    # 檔名一定要用 .npz 結尾——np.savez() 對不是以 .npz 結尾的路徑會自動
+    # 補一個 .npz 副檔名（實測過：傳 "x.npz.tmp" 會真的寫成
+    # "x.npz.tmp.npz"），沒注意到這個行為的話 os.replace() 會找錯檔案。
+    tmp_path = out_path.with_name(out_path.stem + ".tmp.npz")
+    try:
+        np.savez(tmp_path, **arrays)
+        for attempt in range(6):
+            try:
+                os.replace(tmp_path, out_path)
+                break
+            except PermissionError:
+                if attempt == 5:
+                    raise
+                time.sleep(0.1 * (attempt + 1))
+    except BaseException:
+        try:
+            tmp_path.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def acquire_write_lock(out_path: Path, timeout_s: float = 1800.0) -> Path:
+    """對 out_path 的存檔操作加互斥鎖，避免兩個行程同時讀-改-寫同一份
+    npz。O_CREAT|O_EXCL 原子建立模式跟 run_queue.py 的 acquire_lock()
+    同一套，該檔已用這個模式解決過同一類競態，這裡不重新發明。"""
+    lock_path = out_path.with_name(out_path.name + ".lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    t0 = time.time()
+    while True:
+        try:
+            fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            return lock_path
+        except FileExistsError:
+            if time.time() - t0 > timeout_s:
+                print(f"警告：等待 {lock_path.name} 超過 {timeout_s:.0f} 秒"
+                      f"（可能是上一個行程異常結束沒清掉鎖檔），強制視為"
+                      f"可以繼續，手動確認沒有另一個行程還在寫這個檔案。",
+                      flush=True)
+                try:
+                    lock_path.unlink()
+                except FileNotFoundError:
+                    pass
+                continue
+            time.sleep(0.5)
+
+
+def release_write_lock(lock_path: Path) -> None:
+    try:
+        lock_path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def load_partial(out_path: Path) -> dict:
+    """載入上次中斷前已經存檔的部分結果（不含 MANIFEST_KEY）。
+
+    **一定要用 `with` 關掉 `np.load()` 回傳的 `NpzFile`**：實測踩到的
+    Windows 專屬 bug——`NpzFile` 內部持有的 `zipfile.ZipFile` 有循環參照，
+    光靠函式返回時區域變數 `d` 的 refcount 歸零不保證立刻關檔（CPython
+    的世代垃圾回收要等一輪循環偵測才會真的關閉底層檔案控制代碼）。這支
+    函式常常在很短時間內被連續呼叫（`save_progress()` 每存一次檔就呼叫
+    一次），沒關乾淨的控制代碼會卡住 Windows 的 `os.replace()`——同一個
+    路徑被换成新檔案時，作業系統不允許任何控制代碼還開著（不像 POSIX
+    允許 rename 一個仍被打開的檔案），直接丟
+    `PermissionError: [WinError 5] 存取被拒`（2026-08-20 用高速迴圈重複
+    存檔的自動化測試重現到，實機上跑得比較慢、GC 有更多機會介入，
+    平常不容易踩到，但這是真實存在的競態，不是測試環境特有的假象）。"""
+    if not out_path.exists():
+        return {}
+    try:
+        with np.load(out_path, allow_pickle=False) as d:
+            return {k: np.asarray(d[k]) for k in d.files if k != MANIFEST_KEY}
+    except Exception as e:                                        # noqa: BLE001
+        print(f"警告：讀取既有部分結果 {out_path} 失敗（{e}），"
+              f"視為沒有可續傳的進度，從頭開始。", flush=True)
+        return {}
+
+
+def load_manifest(out_path: Path) -> dict | None:
+    """回傳既有存檔裡的 manifest dict；沒有存檔或沒有 manifest 回傳 None。
+
+    同 `load_partial()`：用 `with` 確保 `NpzFile` 立刻關閉，見該函式的
+    說明。"""
+    if not out_path.exists():
+        return None
+    try:
+        with np.load(out_path, allow_pickle=False) as d:
+            if MANIFEST_KEY not in d.files:
+                return None
+            return json.loads(str(d[MANIFEST_KEY]))
+    except Exception:                                             # noqa: BLE001
+        return None
+
+
+def check_manifest(out_path: Path, manifest: dict, partial: dict,
+                   legacy_defaults: dict | None = None) -> None:
+    """比對這次的執行設定跟既有部分結果的 manifest 是否一致，不一致就
+    `sys.exit(1)`（原本是 fit_real.py main() 內嵌的邏輯，逐字抽成共用
+    函式）。`partial` 為空（沒有既有部分結果）時不檢查，直接放行。
+
+    `legacy_defaults`：manifest 裡缺鍵不等於「設定不同」——那個旗標
+    當時根本不存在，舊檔案必定是用它的預設值算出來的（同 fit_real.py
+    的 MANIFEST_LEGACY_DEFAULTS）。"""
+    if not partial:
+        return
+    old_manifest = load_manifest(out_path)
+    legacy_defaults = legacy_defaults or {}
+    if old_manifest is None:
+        print(f"警告：{out_path.name} 是加 manifest 檢查前存的舊檔，"
+              f"無法自動確認這次的設定跟它一致，視為信任沿用。", flush=True)
+        return
+
+    def _old(k):
+        return old_manifest.get(k, legacy_defaults.get(k))
+
+    diffs = {k: (_old(k), v) for k, v in manifest.items() if _old(k) != v}
+    if diffs:
+        print(f"錯誤：{out_path.name} 已有部分結果，但執行設定跟這次不同"
+              f"（{diffs}）。沿用會把兩種不可比的設定混進同一個檔案——"
+              f"換一個 --tag，或確認要不要刪掉舊檔重跑。", flush=True)
+        sys.exit(1)
+
+
+def load_progress(partial: dict, key: str) -> tuple[list, int]:
+    """從 load_partial() 的回傳值取出某個 scan_key 目前的進度。
+
+    回傳 (已成功的結果 list, 已嘗試次數)。「已嘗試」可能大於「已成功」——
+    部分腳本（inject_lowmass.py／injection_recovery.py）遇到貼牆例外會
+    跳過該次、不計入結果，但那個試驗索引真的跑過一次，續傳時不該重跑
+    （重跑只會用同一組亂數種子再得到同一個失敗結果，白工）。永遠成功
+    的腳本（fit_real.py／profile_lowmass.py／profile_outlierfrac.py）
+    不需要在意這個區別，兩個數字本來就相等。"""
+    results = list(partial[key]) if key in partial else []
+    # 前綴（不是後綴）"__"：preflight.gate_c() 用 `not k.startswith("__")`
+    # 篩出「真正的結果鍵」（跟既有的 "__manifest__" 同一個排除規則）。
+    # 用後綴會讓這個記帳用的陣列被 gate_c 誤判成一個真正的結果維度去做
+    # 精修/散布檢查，印出跟這個鍵毫無關係的假警告。
+    att_key = f"__attempted_{key}"
+    if att_key in partial:
+        attempted = int(np.asarray(partial[att_key]).reshape(-1)[-1])
+    else:
+        attempted = len(results)          # 舊格式檔案／永遠成功的腳本
+    return results, attempted
+
+
+def save_progress(out_path: Path, key: str, results: list, manifest: dict,
+                  *, attempted: int | None = None,
+                  extra_arrays: dict | None = None) -> list:
+    """存一個 scan_key 目前的部分結果＋已嘗試次數，回傳實際要沿用的
+    result list（可能被磁碟上更新的版本取代）。
+
+    每算完一次（不管成功或失敗）就呼叫一次——跟 fit_real.py 原本「每次
+    重複算完立刻存檔」同一個顆粒度，中途被砍時最多損失最後一次未存檔
+    的嘗試，不是整批。
+
+    **競態保護跟 fit_real.py 原本內嵌的邏輯相同**：存檔前重新讀一次磁碟
+    上的最新版本，如果磁碟已經比手上這份更進，代表有另一個行程平行在
+    寫同一個輸出檔且比較快，改採用磁碟版本，不要用自己比較舊的覆蓋
+    過去。這只解決「檔案不會被覆蓋壞掉」，不解決「兩個行程各自算了
+    重複的一份卻只留得住一份」——真要跨機器平行擴充，還是要用不重疊的
+    索引分開跑（各自的 --tag），這裡的鎖只是最後一道防線。"""
+    if attempted is None:
+        attempted = len(results)
+    att_key = f"__attempted_{key}"
+    lock_path = acquire_write_lock(out_path)
+    try:
+        fresh = load_partial(out_path)
+        disk_attempted = int(np.asarray(fresh[att_key]).reshape(-1)[-1]) \
+            if att_key in fresh else len(fresh.get(key, []))
+        if disk_attempted > attempted:
+            print(f"  [注意] 磁碟上 {key} 已嘗試 {disk_attempted} 次，比這個"
+                  f"行程手上的 {attempted} 次多（可能有另一個行程平行在跑同一個"
+                  f"輸出檔），改沿用磁碟版本繼續。", flush=True)
+            results = list(fresh[key]) if key in fresh else []
+            attempted = disk_attempted
+        out = {k: v for k, v in fresh.items() if k != key and k != att_key}
+        if results:
+            out[key] = np.array(results)
+        out[att_key] = np.array([attempted])
+        if extra_arrays:
+            out.update(extra_arrays)
+        manifest_arr = np.array(json.dumps(manifest, sort_keys=True))
+        atomic_savez(out_path, **out, **{MANIFEST_KEY: manifest_arr})
+    finally:
+        release_write_lock(lock_path)
+    return results

--- a/scripts/tools/checkpoint.py
+++ b/scripts/tools/checkpoint.py
@@ -57,6 +57,29 @@ import numpy as np
 MANIFEST_KEY = "__manifest__"
 
 
+def _retry_permission_error(fn, *, attempts: int = 12):
+    """對 `fn()` 做有上限的重試，只吞 `PermissionError`（Windows 上防毒／
+    索引服務對剛寫完／剛要讀的檔案短暫佔用的已知現象，見 `atomic_savez()`
+    的說明）。重試次數用完仍失敗就把最後一次的例外原樣往上拋，不會無限期
+    忽略；任何非 `PermissionError` 的例外直接原樣拋出、不重試——那類錯誤
+    重試沒有意義，只會拖慢真正失敗的訊號。
+
+    **重試預算（12 次、每次間隔遞增到最多 1 秒，總計最壞情況約 6.5 秒）
+    是實測調出來的，不是隨手訂的數字**：一開始用 6 次、每次最多 0.5 秒
+    （總計約 1.5 秒），在這台機器背景同時跑著其他計算工作（CPU 滿載）
+    時仍然重現到重試次數用完仍失敗——代表防毒／索引服務在系統忙碌時
+    掃描一個剛寫完的小檔案，可能需要比 1.5 秒更長。6.5 秒對單次擬合
+    動輒數分鐘的真實產線來說仍然可忽略，但給了明顯更多餘裕撐過系統
+    忙碌的窗口。"""
+    for attempt in range(attempts):
+        try:
+            return fn()
+        except PermissionError:
+            if attempt == attempts - 1:
+                raise
+            time.sleep(min(0.1 * (attempt + 1), 1.0))
+
+
 def atomic_savez(out_path: Path, **arrays) -> None:
     """np.savez 不是原子操作——寫到一半被中斷（斷電、被砍行程）會留下
     截斷或空的檔案，蓋掉前一次跑成功的 checkpoint。改成寫到同目錄的
@@ -83,14 +106,7 @@ def atomic_savez(out_path: Path, **arrays) -> None:
     tmp_path = out_path.with_name(out_path.stem + ".tmp.npz")
     try:
         np.savez(tmp_path, **arrays)
-        for attempt in range(6):
-            try:
-                os.replace(tmp_path, out_path)
-                break
-            except PermissionError:
-                if attempt == 5:
-                    raise
-                time.sleep(0.1 * (attempt + 1))
+        _retry_permission_error(lambda: os.replace(tmp_path, out_path))
     except BaseException:
         try:
             tmp_path.unlink()
@@ -132,8 +148,11 @@ def release_write_lock(lock_path: Path) -> None:
         pass
 
 
-def load_partial(out_path: Path) -> dict:
-    """載入上次中斷前已經存檔的部分結果（不含 MANIFEST_KEY）。
+def _read_npz_dict(out_path: Path) -> dict:
+    """實際讀檔的共用邏輯：回傳 out_path 裡除了 MANIFEST_KEY 以外的全部
+    鍵值。呼叫端必須自己處理「檔案不存在」（這裡不判斷）與讀取例外——
+    寬鬆版本（`load_partial()`）跟嚴格版本（`_load_partial_strict()`）
+    對這兩種情況的處置完全不同，見兩者各自的說明。
 
     **一定要用 `with` 關掉 `np.load()` 回傳的 `NpzFile`**：實測踩到的
     Windows 專屬 bug——`NpzFile` 內部持有的 `zipfile.ZipFile` 有循環參照，
@@ -146,15 +165,47 @@ def load_partial(out_path: Path) -> dict:
     `PermissionError: [WinError 5] 存取被拒`（2026-08-20 用高速迴圈重複
     存檔的自動化測試重現到，實機上跑得比較慢、GC 有更多機會介入，
     平常不容易踩到，但這是真實存在的競態，不是測試環境特有的假象）。"""
+    with np.load(out_path, allow_pickle=False) as d:
+        return {k: np.asarray(d[k]) for k in d.files if k != MANIFEST_KEY}
+
+
+def load_partial(out_path: Path) -> dict:
+    """載入上次中斷前已經存檔的部分結果（不含 MANIFEST_KEY），供「只是
+    想看一眼跑到哪裡」的呼叫端用（例如 `preflight.workload_audit()` 要
+    印進度、或腳本要決定跳過哪些已完成的重複）。**讀取失敗（不管是檔案
+    真的不存在，還是存在但讀不出來）一律印警告、回傳 `{}`，視為沒有
+    進度可續傳**——這個寬鬆行為只適用於「讀」的情境，不能被拿去給
+    `save_progress()` 內部判斷要不要覆寫檔案用，見
+    `_load_partial_strict()` 的說明為什麼那裡需要嚴格版本。"""
     if not out_path.exists():
         return {}
     try:
-        with np.load(out_path, allow_pickle=False) as d:
-            return {k: np.asarray(d[k]) for k in d.files if k != MANIFEST_KEY}
+        return _read_npz_dict(out_path)
     except Exception as e:                                        # noqa: BLE001
         print(f"警告：讀取既有部分結果 {out_path} 失敗（{e}），"
               f"視為沒有可續傳的進度，從頭開始。", flush=True)
         return {}
+
+
+def _load_partial_strict(out_path: Path) -> dict:
+    """`save_progress()` 專用的嚴格版本：檔案不存在回傳 `{}`（合法情況，
+    第一次存檔本來就沒有舊檔），但**檔案存在卻讀不出來時直接把例外往上
+    拋，不吞掉**（對 `PermissionError` 先重試幾次，見
+    `_retry_permission_error()`，重試用完仍失敗才真的拋出）。
+
+    這跟 `load_partial()` 刻意不同：`save_progress()` 讀完 `fresh` 之後，
+    會拿讀到的內容當「磁碟上其餘 scan_key 的既有結果」原封不動寫回去
+    （只覆寫自己這次要存的那個 key）。如果讀取失敗被吞成 `{}`（跟
+    `load_partial()` 一樣的寬鬆行為），`save_progress()` 會誤判成
+    「磁碟上什麼都沒有」，接著用「只含當前這一個 scan_key」的內容原子性
+    覆蓋掉整個檔案——磁碟上其他 scan_key 已經算完的結果就永久消失了。
+    這正是這整個 PREFLIGHT／checkpoint 機制想防的「看起來成功（`exit
+    0`、有寫出檔案），資料卻不是我們以為的那樣」的失敗形狀，換個地方在
+    自己身上重演一次，所以這裡必須用會出聲的嚴格版本
+    （2026-08-20 CodeRabbit review）。"""
+    if not out_path.exists():
+        return {}
+    return _retry_permission_error(lambda: _read_npz_dict(out_path))
 
 
 def load_manifest(out_path: Path) -> dict | None:
@@ -245,7 +296,12 @@ def save_progress(out_path: Path, key: str, results: list, manifest: dict,
     att_key = f"__attempted_{key}"
     lock_path = acquire_write_lock(out_path)
     try:
-        fresh = load_partial(out_path)
+        # 用嚴格版本，不是 load_partial()：讀取失敗（不管是暫時的
+        # PermissionError 還是真的損毀）在這裡絕對不能被吞成「當作沒有
+        # 進度」——那會讓下面的 atomic_savez() 拿只含這個 key 的內容
+        # 覆蓋掉磁碟上其他 scan_key 已經算完的結果，見
+        # _load_partial_strict() 的說明。
+        fresh = _load_partial_strict(out_path)
         disk_attempted = int(np.asarray(fresh[att_key]).reshape(-1)[-1]) \
             if att_key in fresh else len(fresh.get(key, []))
         if disk_attempted > attempted:

--- a/scripts/tools/preflight.py
+++ b/scripts/tools/preflight.py
@@ -278,14 +278,82 @@ def audit_common(model, grid, refines, *, script: str,
     return fails, warns
 
 
+def workload_audit(*, scan_keys: list[str], repeats: int, n_syn: int,
+                   n_obs: int, refines: list[int], partial_counts: dict,
+                   unit: str = "次重複", unknown: list[str] | None = None,
+                   known: list[str] | None = None,
+                   scan_label: str = "掃描項目") -> tuple[list[str], list[str]]:
+    """B1（意圖對帳）的通用實作，回傳 (fails, warns)，印【工作量】段落。
+
+    2026-08-20：原本 B1 只有 `fit_real.py` 有（`_preflight_report()` 裡
+    手寫的一段），其餘四支診斷腳本旗標介面互不相同（`--configs` vs
+    `--slopes`／`--fracs` vs `--trials`+`--only` vs `--scenarios`），
+    沒有共用同一套邏輯。這裡不去認得每支腳本的旗標名稱，而是要求呼叫端
+    先把自己的旗標解析成同一組共同形狀——「一串 scan_key（設定名稱、
+    冪次、污染比例、真值、情境……字串化後的鍵）＋ 每個 key 重複幾次」，
+    這組形狀所有五支腳本都套得上，不用再各寫一份印報表／算 n_new 的
+    邏輯（那正是 B1/B2 遲遲沒有推廣的原因——覺得每支腳本都要重寫一份
+    不划算，這裡把「重寫」的部分收斂成「轉換成共同形狀」）。
+
+    `partial_counts`：`{scan_key: 已嘗試次數}`，用 `checkpoint.load_progress()`
+    算出來的 attempted（不是純成功次數——已經跑過但失敗的也不該重跑，
+    見 checkpoint.py 的說明）。"""
+    fails, warns = [], []
+    if unknown:
+        fails.append(f"{scan_label}有不存在的名稱 {unknown}"
+                     f"（可用：{', '.join(known or [])}），"
+                     f"它們會被靜默略過，實際只會處理已知的那些")
+    n_new = sum(max(0, repeats - partial_counts.get(k, 0)) for k in scan_keys)
+    print("\n【工作量】", flush=True)
+    print(f"  {scan_label}          {', '.join(scan_keys) or '(無)'}"
+          f"（{len(scan_keys)} 項）", flush=True)
+    print(f"  每項重複           {repeats} {unit}", flush=True)
+    print(f"  已完成、會跳過     {partial_counts or '無'}", flush=True)
+    print(f"  這次實際要算       {n_new} {unit}", flush=True)
+    print(f"  精修階數           {refines}"
+          f"（粗網格 + {len(refines)} 階精修）", flush=True)
+    print(f"  合成星數 n_syn     {n_syn:,}", flush=True)
+    print(f"  觀測星數           {n_obs:,}", flush=True)
+    if n_new == 0 and scan_keys:
+        warns.append("這次沒有任何新的工作要算（既有結果已滿足重複次數），"
+                     "跑起來會立刻結束")
+    return fails, warns
+
+
+def output_audit(out_path: Path, partial: dict,
+                 resume_desc: str = "有（每次嘗試算完立刻存檔＋寫入鎖，"
+                                    "見 scripts/tools/checkpoint.py）") -> None:
+    """B2（輸出狀態）的通用實作，只印報告，不產生 fails——manifest 不相容
+    的情況在呼叫這支函式之前，`checkpoint.check_manifest()` 就已經
+    `sys.exit(1)` 擋掉了，走到這裡只會是「沒有舊檔」或「舊檔相容」，
+    是報告不是判斷（跟 fit_real.py 原本 `_preflight_report()` 的【輸出】
+    段落同一個道理）。"""
+    print("\n【輸出】", flush=True)
+    print(f"  檔案               results/{out_path.name}", flush=True)
+    print(f"  目前狀態           "
+          f"{'已存在，設定相容，會續傳' if partial else '不存在，從頭開始'}",
+          flush=True)
+    print(f"  續傳保護           {resume_desc}", flush=True)
+
+
 def mandatory_gate(model, grid, refines, *, script: str,
                    expected_overrides: dict | None = None,
-                   force: bool = False, dry_run: bool = False) -> None:
+                   force: bool = False, dry_run: bool = False,
+                   extra_fails: list[str] | None = None,
+                   extra_warns: list[str] | None = None) -> None:
     """五支計算腳本的 `main()` 都在建好 `model`（`JointModel`）之後、開始
     真正計算之前，無條件呼叫這支函式一次——不是選用旗標，是預設行為。
     這樣不管從哪台機器、用什麼方式呼叫（`run_queue.py`、Kaggle 筆記本、
     x64 協作機手動下指令），檢查都會發生，不依賴呼叫端記得先跑
     `--preflight`。
+
+    `extra_fails`／`extra_warns`：呼叫端先跑過 `workload_audit()`（B1）
+    算出的 fails/warns，併入這裡的最終判定與印出的摘要——B1 沒有阻擋
+    級問題就不該讓計算被 A2/A3 以外的原因擋下來，反過來也一樣，兩邊
+    的 fails 是同一個「通不通過」判定的兩個來源，不能分開判。呼叫端
+    應該在呼叫這支函式之前先印好【工作量】／【輸出】兩節（見
+    `workload_audit()`／`output_audit()`），這裡只接手 A2/A3 那段報告
+    與最終摘要，不重複印一次。
 
     `dry_run=True`（對應各腳本的 `--preflight` 旗標）：印完報告就結束，
     不管有沒有阻擋都不會繼續往下跑，回傳碼視結果而定——這是「只檢查」
@@ -301,6 +369,8 @@ def mandatory_gate(model, grid, refines, *, script: str,
     print("=" * 74, flush=True)
     fails, warns = audit_common(model, grid, refines, script=script,
                                 expected_overrides=expected_overrides)
+    fails = list(fails) + list(extra_fails or [])
+    warns = list(warns) + list(extra_warns or [])
     print("\n" + "=" * 74, flush=True)
     for w in warns:
         print(f"  注意：{w}", flush=True)
@@ -333,13 +403,21 @@ def _has_resume(script: str) -> bool:
     """這支腳本撐不撐得過中途被砍（重開機／卡死重試）。
 
     用讀原始碼判斷而不是維護一份名單：名單會過期，而且新腳本加進來時
-    不會有人記得回來更新。找的是 `load_partial`／`MANIFEST_KEY` 這組
-    `fit_real.py` 既有的續傳 pattern。
+    不會有人記得回來更新。
+
+    2026-08-20：續傳邏輯統一搬進 `scripts/tools/checkpoint.py` 共用模組
+    （原本只有 `fit_real.py` 自己一份，`inject_lowmass.py` 部分做到一半，
+    `profile_lowmass.py`／`profile_outlierfrac.py`／`injection_recovery.py`
+    完全沒有）。找的是有沒有 `import checkpoint`；`load_partial`／
+    `MANIFEST_KEY` 這組舊 pattern 留著當備援，涵蓋還沒改用共用模組、
+    但自己重新實作了同一套邏輯的腳本。
     """
     p = HERE / script
     if not p.exists():
         return False
     src = p.read_text(encoding="utf-8", errors="replace")
+    if re.search(r"^\s*import checkpoint\b", src, re.MULTILINE):
+        return True
     return "load_partial" in src and "MANIFEST_KEY" in src
 
 
@@ -350,12 +428,14 @@ def gate_b(only_pending=True, verbose=True) -> list[str]:
     `profile_lowmass.py`／`profile_outlierfrac.py`／`inject_lowmass.py`／
     `injection_recovery.py`，五支計算腳本全部）的行都會實際呼叫
     `--preflight` 代跑一次（用它自己的 parser 與模型建構，不會跟本體
-    不同步），拿到 A2（設定對帳）／A3（網格涵蓋）的完整檢查——但只有
-    `fit_real.py` 有 B1（意圖對帳）／B2（輸出衝突），其餘四支的旗標
-    介面互不相同，沒有硬套同一份邏輯。名單外的腳本只做得到 B3
-    （續傳能力）這層靜態檢查——**這個涵蓋差異會照實印出來，不會讓人
-    以為每一行都受到同等程度的檢查**（CodeRabbit review 抓到這裡的
-    docstring 沒跟上實作，五支腳本擴充後忘記回來更新）。
+    不同步），拿到 A2（設定對帳）／A3（網格涵蓋）／B1（意圖對帳）／
+    B2（輸出衝突）的完整檢查——五支腳本旗標介面互不相同，但透過
+    `preflight.workload_audit()`／`output_audit()` 共用同一套邏輯（見
+    該函式說明），不是各自硬寫一份。B3（續傳能力）另外用 `_has_resume()`
+    讀原始碼判斷，五支現在都用 `scripts/tools/checkpoint.py`，全部為真。
+    名單外（不在 `PREFLIGHT_AWARE_SCRIPTS`）的腳本只做得到 B3 這層靜態
+    檢查——**這個涵蓋差異會照實印出來，不會讓人以為每一行都受到同等
+    程度的檢查**。
     """
     import run_queue as rq
     items = rq.read_queue()


### PR DESCRIPTION
## 背景

同一天稍早建好的 Preflight 三關卡系統（見 #83/#84）留了兩個誠實記錄的缺口：

- **B1/B2（意圖對帳、輸出衝突）** 只有 `fit_real.py` 有，其餘四支診斷腳本（`profile_lowmass.py`/`profile_outlierfrac.py`/`inject_lowmass.py`/`injection_recovery.py`）旗標介面互不相同，沒有硬套。
- **B3（續傳）** 本身沒解決：這四支腳本要嘛完全沒有續傳（只在最後 `np.savez` 一次），要嘛做到一半（`inject_lowmass.py` 存了但重啟不會讀回）。中途被 Windows 強制重開機（本機過去四天發生至少 4 次）就要從頭重算，即使前面算完的部分本身沒問題。

這個 PR 補齊這兩個缺口。詳細背景與設計理由見 `docs/reference/PREFLIGHT.md` 新增的「B1／B2 推廣到五支腳本、B3 補齊四支診斷腳本」一節。

## 做了什麼

**新增 `scripts/tools/checkpoint.py`**：把 `fit_real.py` 原本自己的 `atomic_savez()`/存取鎖/`load_partial()`/manifest 比對收斂成共用模組——`fit_real.py` 自己也改成呼叫這份，不再維護複本（這正是這個專案已經在 A2/A3 上吃過一次虧的模式：共用邏輯建好後，原始那份沒跟著改，兩份不同步；這次提前收斂掉）。用 `attempted`（已嘗試次數，跟已成功次數分開記）處理 `inject_lowmass.py` 的貼牆例外——失敗的試驗索引真的跑過一次，續傳時不該重跑。

**`preflight.py` 新增 `workload_audit()`/`output_audit()`**：不去認得每支腳本的旗標名稱，改成要求呼叫端先把旗標轉換成共同形狀（`scan_keys` + `repeats`）再呼叫。五支腳本（含 `fit_real.py` 自己）都改用這組共用邏輯。連帶把 `injection_recovery.py` 原本「未知情境靜默略過」升級成跟 `fit_real.py` 打錯 `--configs` 一樣的處理：可被 `--force` 略過的阻擋 + 不能被 `--force` 繞過的硬 `sys.exit(1)`。

**過程中抓到一個真實 Windows bug**：用高速迴圈測試連續存檔時，`os.replace()` 偶發 `PermissionError: [WinError 5]`。根因之一是 `np.load()` 回傳的 `NpzFile` 沒用 `with` 關閉，已修正；另一部分是 Windows 上防毒/索引服務對剛寫完的暫存檔短暫佔用的已知現象，改成對 `PermissionError` 做有上限的重試（跟既有 `acquire_write_lock()` 同一類「等一下再試」處置）。

## 驗證

- 五支腳本各自 `--preflight` dry-run（含故意打錯設定/情境名稱，確認阻擋正確觸發、`--force` 可繞過 vs 不可繞過的兩種阻擋都測過）
- `checkpoint.py` 核心函式（`save_progress`/`load_progress`/`check_manifest`）直接單元測試，含跨行程競態、legacy 檔案相容性、`gate_c()` 對記帳鍵的排除
- `inject_lowmass.py`/`injection_recovery.py`/`profile_lowmass.py` 各自用假的 `multi_stage_best()`/`make_fake()`（跳過真正的合成星團運算）跑過完整的「執行→中斷→重啟」流程，確認已完成項目正確跳過、不重算
- 未實際等待真實擬合跑完全程（`inject_lowmass.py` 單次試驗 `--procs 1` 實測需 385 分鐘）——這條路徑的信心來自這些函式是從已在生產環境跑了幾天的 `fit_real.py` 抽出來的共用邏輯，不是全新未驗證的東西，`PREFLIGHT.md` 裡誠實記錄了這個範圍

期間本機 `radial_r1_final` 背景工作全程未受影響（未觸碰其輸出檔）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 五項計算流程支援中斷後續傳與進度檢查點。
  * 每次嘗試後即保存進度，重跑時可跳過已嘗試項目。
  * 執行前新增工作量、輸出、設定與掃描範圍檢查，並支援強制執行與乾跑。
  * 未知情境會直接阻擋執行，避免產生無效結果。

* **錯誤修正**
  * 改善 Windows 儲存流程的穩定性與檔案鎖定處理。
  * 新增結果檔與設定驗證，降低資料不一致風險。
  * 新增重複次數參數驗證。

* **文件**
  * 更新 preflight 驗證範圍、結果與已知限制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->