### PR TITLE
解除 D2 阻擋：fetch_gaia.py 加 --top / --ra / --dec，成功抓回原始 Gaia 檔

### DIFF
--- a/WORK_BOARD.md
+++ b/WORK_BOARD.md
@@ -131,8 +131,8 @@ COUNT(*) 查詢在 ESA 端逾時（不是本機網路），主查詢本身不做
 天區必須跟原本一致，否則量到的差異會混進「天區不同」這個額外變因。
 
 正確的重抓指令是：
-`python scripts/data_prep/fetch_gaia.py --target M45 --ra 56.60083 --dec 24.11389 --radius 5.0 --gmax 18.0 --plxmin 4.0 --top 20000`
-（檔案在 `.gitignore` 裡，不進版控，換機器要自己重抓一次。）
+`python scripts/data_prep/fetch_gaia.py --target M45 --ra 56.60083 --dec 24.11389 --radius 5.0 --gmax 18.0 --plxmin 4.0 --top 20000 --force`
+（檔案在 `.gitignore` 裡，不進版控，換機器要自己重抓一次。**`--force` 是必要的**：`fetch_gaia.py` 第 120 行對已存在的輸出檔會直接印「已存在，跳過」就結束，不加的話在已經抓過的機器上重跑這行等於什麼都沒做，卻看不出來——2026-08-21 CodeRabbit review 抓到。乾淨的新機器上不帶 `--force` 也會動，但照著這行複製貼上的人多半是想重抓。)
 
 **下一步**：可以跑 `python scripts/diagnostics/sensitivity_sweep.py --target membership_threshold` 了。
 - `--target stars_per_cluster`：這個設定要真的重跑 pyUPMASK 聚類，不是重新套門檻能測的。這台機器沒有 `pyUPMASK/` 目錄（未驗證能不能跑），腳本會誠實報告做不到，不會編造數字——已內建這個可行性檢查，**不要跳過檢查直接猜答案**。留給有 pyUPMASK 環境的 session。

--- a/WORK_BOARD.md
+++ b/WORK_BOARD.md
@@ -116,6 +116,25 @@ B 類，沒有非 A/B 類項目排在中間，`queue.txt` 已經符合要求，�
 
 **D2 進度說明（2026-08-19）**：`scripts/diagnostics/sensitivity_sweep.py` 已寫好，涵蓋兩種目標：
 - `--target membership_threshold`：重新套用 `results/baseline.dat` 的成員機率門檻 -> 重跑第 2/3 步 -> 用 config C 跑一次前向模型，量 alpha 敏感度。**流程已驗證可行**（本機用小規模參數試跑通過），但完整掃描需要原始 Gaia 查詢 CSV（`data/m45_r5_g18_plx4.csv`，6,956 顆未篩選），這台機器原本沒有，追查後發現產生它的 `fetch_gaia.py` 依賴另一個私有 repo `github.com/helmet-png/gaia-dr3-export`——已 clone 到 `Documents/` 同層解鎖依賴，但重抓時卡在第一步：`fetch_gaia.py` 會先送一個 `SELECT COUNT(*)` 查詢決定要抓幾筆，這個查詢對 18 億列的 `gaia_source` 做 5 度錐形 + G<=18 + parallax>=4 篩選，**手動重現並拿到完整錯誤內文，確認是 ESA 伺服器端主動取消**：`SQL exception: ERROR: canceling statement due to statement timeout`（等了 183 秒後被砍），不是本機網路或帳號問題，是這個特定 COUNT 查詢在伺服端太重、撞到它自己的 statement timeout。**已知可能的解法**（留給下一個 session，這是 `gaia-dr3-export` 那個獨立 repo 的程式，不在這個專案範圍內改）：跳過精確計數，直接在主查詢用一個夠大的 `TOP`（例如 20000，M45 這個天區遠不會到這個量級）取代 `count_sources()` 那一步。**下一個 session 檢查 `data/m45_r5_g18_plx4.csv` 是否已成功抓到**，有的話直接跑 `python scripts/diagnostics/sensitivity_sweep.py --target membership_threshold`（預設掃 0.5/0.6/0.7/0.8/0.9 五個門檻，`--n-syn 40000 --refines 3,3` 較準，示範用可以先 `--n-syn 5000 --refines 3` 求快），沒有的話重跑 `python scripts/data_prep/fetch_gaia.py --target M45 --radius 5.0 --gmax 18.0 --plxmin 4.0 --force`。
+
+**2026-08-21：阻擋已解除，檔案抓到了**。原因確認是 `count_sources()` 那個
+COUNT(*) 查詢在 ESA 端逾時（不是本機網路），主查詢本身不做 COUNT、只取前 N 列
+反而跑得動。已幫 `fetch_gaia.py` 加兩個旗標（**改的是本專案的檔案，不是那個
+私有 repo**）：`--top` 跳過精確計數（並在取回列數頂到上限時中止、不靜默給
+截斷資料），`--ra`／`--dec` 跳過 Sesame 名稱解析。
+
+**`--ra`／`--dec` 不是可有可無**：Sesame 對 M45 回 RA=56.86909，跟
+`config.toml [target]` 註解記的 56.60083 差 0.27 度，錐形位置跟著偏——實測
+用 Sesame 座標抓到 6,986 顆，既有 `cmd_members.csv` 的 1,078 顆成員有 **2 顆
+落到錐形外面**（覆蓋率 99.81%）。改用 config 的座標後抓到 **6,956 顆，跟本表
+原本記載的數字完全一致，成員覆蓋率 1,078/1,078 = 100%**。敏感度比較的輸入
+天區必須跟原本一致，否則量到的差異會混進「天區不同」這個額外變因。
+
+正確的重抓指令是：
+`python scripts/data_prep/fetch_gaia.py --target M45 --ra 56.60083 --dec 24.11389 --radius 5.0 --gmax 18.0 --plxmin 4.0 --top 20000`
+（檔案在 `.gitignore` 裡，不進版控，換機器要自己重抓一次。）
+
+**下一步**：可以跑 `python scripts/diagnostics/sensitivity_sweep.py --target membership_threshold` 了。
 - `--target stars_per_cluster`：這個設定要真的重跑 pyUPMASK 聚類，不是重新套門檻能測的。這台機器沒有 `pyUPMASK/` 目錄（未驗證能不能跑），腳本會誠實報告做不到，不會編造數字——已內建這個可行性檢查，**不要跳過檢查直接猜答案**。留給有 pyUPMASK 環境的 session。
 
 

--- a/scripts/data_prep/fetch_gaia.py
+++ b/scripts/data_prep/fetch_gaia.py
@@ -88,6 +88,28 @@ def main():
     ap.add_argument("--plxmin", type=float, default=4.0,
                     help="視差下限（mas）；給 0 表示不切，對照跑用")
     ap.add_argument("--force", action="store_true", help="已有檔案也重抓")
+    ap.add_argument("--ra", type=float, default=None,
+                    help="錐形中心 RA（度），跳過 Sesame 名稱解析。"
+                         "**要重現既有樣本時一定要用**：Sesame 對 M45 回的是"
+                         "RA=56.86909，跟 config.toml [target] 註解裡記的"
+                         "56.60083 差 0.27 度，錐形位置跟著偏，實測會讓既有"
+                         "cmd_members.csv 的 1,078 顆成員有 2 顆落到新錐形外面。"
+                         "做敏感度比較時輸入天區必須跟原本一致，否則量到的差異"
+                         "會混進「天區不同」這個額外變因。")
+    ap.add_argument("--dec", type=float, default=None,
+                    help="錐形中心 Dec（度），跟 --ra 一起給。見 --ra 的說明。")
+    ap.add_argument("--top", type=int, default=None,
+                    help="跳過 count_sources() 的精確計數，直接用這個上限查。"
+                         "**這是為了繞過伺服器端的硬限制，不是效能微調**："
+                         "count_sources() 會對 18 億列的 gaia_source 做錐形+"
+                         "星等+視差篩選再 COUNT(*)，M45 這組參數實測在 ESA 端"
+                         "跑 183 秒後被伺服器自己的 statement timeout 砍掉"
+                         "（錯誤是 canceling statement due to statement "
+                         "timeout，不是本機網路問題），整條 D2 敏感度掃描因此"
+                         "卡住（見 WORK_BOARD.md D2 進度說明）。主查詢本身不做"
+                         "COUNT、只取前 N 列，反而跑得動。給值時會檢查實際取回"
+                         "的列數有沒有頂到上限，頂到就中止並要求調大，不會靜默"
+                         "給出一份被截斷的資料。")
     a = ap.parse_args()
     server = _load_server()
 
@@ -99,8 +121,16 @@ def main():
         print(f"已存在，跳過：{out.name}（要重抓加 --force）")
         return
 
-    ra, dec = server.resolve_name(a.target)
-    print(f"{a.target} -> RA={ra:.5f}, Dec={dec:.5f}")
+    if (a.ra is None) != (a.dec is None):
+        ap.error("--ra 與 --dec 要嘛都給、要嘛都不給（只給一個會靜默用"
+                 "Sesame 的另一半座標，錐形中心變成兩個來源的混合）")
+    if a.ra is not None:
+        ra, dec = a.ra, a.dec
+        print(f"{a.target} -> RA={ra:.5f}, Dec={dec:.5f}（手動指定，"
+              f"跳過 Sesame）")
+    else:
+        ra, dec = server.resolve_name(a.target)
+        print(f"{a.target} -> RA={ra:.5f}, Dec={dec:.5f}（Sesame 解析）")
 
     params = {
         "mode": "cone", "ra": ra, "dec": dec, "radius": a.radius,
@@ -109,14 +139,27 @@ def main():
     if a.plxmin > 0:
         params["parallax_min"] = a.plxmin
 
-    n = server.count_sources(params)
-    print(f"符合條件：{n:,} 顆")
+    if a.top is not None:
+        n = a.top
+        print(f"跳過精確計數，直接用上限 {n:,} 查（--top）")
+    else:
+        n = server.count_sources(params)
+        print(f"符合條件：{n:,} 顆")
 
     adql = server.build_adql(params, top=n)
     print("查詢中…（大天區不切視差時會走 async，可能要數分鐘）")
     data = server.run_tap_query(adql, "csv")
-    out.write_bytes(data)
     rows = data.count(b"\n") - 1
+    # 頂到上限就可能被截斷。**先檢查再寫檔**——寫下去之後下游沒有任何一步
+    # 看得出這份資料是完整的還是被切一半的，那正是這個專案最怕的
+    # 「檔案存在、數字看起來正常、其實不是我們以為的那個」。
+    if a.top is not None and rows >= a.top:
+        print(f"錯誤：取回 {rows:,} 列，等於或超過 --top {a.top:,} 的上限，"
+              f"資料**可能被截斷**。把 --top 調大再跑一次（M45 這組參數的"
+              f"實際量級約 7,000 顆，設 20000 有足夠餘裕）。沒有寫檔。",
+              flush=True)
+        raise SystemExit(1)
+    out.write_bytes(data)
     print(f"寫入 {out}（{rows:,} 列，{len(data):,} bytes）")
 
 


### PR DESCRIPTION
## 問題

D2 敏感度掃描卡在 `data/m45_r5_g18_plx4.csv` 抓不到。原因確認是 `count_sources()` 的 `COUNT(*)` 對 18 億列的 `gaia_source` 做錐形+星等+視差篩選，在 ESA 端跑 183 秒後被**伺服器自己的 statement timeout** 砍掉（不是本機網路問題）。

主查詢本身不做 COUNT、只取前 N 列，反而跑得動。

## 兩個旗標（改的是本專案的檔案，不是那個私有 repo）

**`--top`**：跳過精確計數。並在取回列數頂到上限時**中止且不寫檔**——寫下去之後下游沒有任何一步看得出資料是完整的還是被截斷的，那正是本專案最怕的「檔案存在、數字看起來正常、其實不是我們以為的那個」。

**`--ra` / `--dec`**：跳過 Sesame 名稱解析。**這不是可有可無**：

| 錐形中心 | 來源 | 抓到 | 既有成員覆蓋率 |
|---|---|---|---|
| RA=56.86909 | Sesame | 6,986 顆 | 1,076/1,078 = **99.81%**（2 顆落到錐形外）|
| RA=56.60083 | `config.toml [target]` 註解 | **6,956 顆** | **1,078/1,078 = 100%** |

6,956 跟 `WORK_BOARD.md` 原本記載的數字完全一致。敏感度比較的輸入天區必須跟原本一致，否則量到的差異會混進「天區不同」這個額外變因。

只給 `--ra` 或只給 `--dec` 會被 argparse 擋下（避免錐形中心變成兩個來源的混合）。

## 正確的重抓指令

```
python scripts/data_prep/fetch_gaia.py --target M45 --ra 56.60083 --dec 24.11389 --radius 5.0 --gmax 18.0 --plxmin 4.0 --top 20000
```

CSV 本身在 `.gitignore` 裡不進版控（1.6 MB，可重現）。已複製一份到主工作樹，`sensitivity_sweep.py` 現在可以跑了。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 可手動指定赤經與赤緯作為搜尋中心；未指定時將使用名稱解析。
  * 新增限制查詢筆數的選項，提升大量資料擷取時的彈性。
  * 查詢結果達到上限時會提示可能不完整，並避免產生截斷的輸出檔。

* **文件**
  * 更新 Gaia 資料重抓指令，說明需使用 `--force` 才會覆寫既有輸出檔。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->