### PR TITLE
watchdog 改用單例鎖檔判斷，修掉相對路徑啟動時每 15 分鐘誤開一份的問題

### DIFF
--- a/restart_queue_on_boot.ps1
+++ b/restart_queue_on_boot.ps1
@@ -73,6 +73,37 @@ function Restart-QueueIfNotRunning {
     $scriptPath = Join-Path $repo $ScriptName
     $queueLog = Join-Path $repo "logs\$LogFile"
 
+    # 第一優先：看單例鎖檔。這是跟 Python 端同一個真相來源——run_queue.py
+    # 與 kaggle_queue.py 的 acquire_lock() 就是用這個檔案判斷「有沒有另一
+    # 份在跑」，兩邊用同一個判準才不會各說各話。
+    #
+    # **為什麼不能只靠命令列比對**（2026-08-21 實測到的問題）：下面那段
+    # 比對要求命令列裡出現腳本的**完整絕對路徑**，但用相對路徑啟動
+    # （`Set-Location $repo; python -u kaggle_queue.py`）時命令列裡只有
+    # 裸檔名，比對不到，於是這支腳本每 15 分鐘都誤判成「沒在跑」而多開
+    # 一份。那些多開的行程雖然一啟動就被 Python 端的單例鎖擋掉、自己
+    # 退出（所以沒造成真正的傷害），但等於每輪都白開一個行程、還把
+    # autorestart.log 灌滿假的「自動重啟」紀錄，真的出事時反而看不出來。
+    # 這正是 acquire_lock() 註解裡記的 2026-08-18 那次「相對路徑啟動
+    # 導致漏配」的同一個坑，只是這次是持續每 15 分鐘重演。
+    $lockFile = Join-Path $repo ("logs\" + [IO.Path]::GetFileNameWithoutExtension($ScriptName) + ".lock")
+    if (Test-Path $lockFile) {
+        $lockPid = $null
+        try { $lockPid = [int]((Get-Content $lockFile -Raw).Trim()) } catch { $lockPid = $null }
+        if ($lockPid) {
+            $alive = Get-Process -Id $lockPid -ErrorAction SilentlyContinue
+            if ($alive) {
+                Write-SelfLog "$ScriptName 已在跑（鎖檔 PID $lockPid），略過重複啟動"
+                return
+            }
+            # 鎖檔在、PID 卻不在 = 上次沒清乾淨。**不在這裡刪**：Python 端的
+            # acquire_lock() 自己會偵測殘留鎖並清掉重搶，由它處理才不會跟
+            # 正在啟動中的行程搶。這裡只當作「沒在跑」，往下走重啟流程。
+            Write-SelfLog "$ScriptName 的鎖檔殘留（PID $lockPid 已不存在），視為沒在跑"
+        }
+    }
+
+    # 第二道：命令列比對。鎖檔不存在時（例如還沒跑過任何一次）才用得上。
     # 只比對這個 repo 自己的腳本完整路徑，不是裸的檔名片段——避免別的
     # checkout、備份檔（例如 run_queue.py.bak）之類的命令列片段誤判成
     # 「已經在跑」，導致該重啟的時候被誤判成略過（CodeRabbit review


### PR DESCRIPTION
## 問題（2026-08-21 實測到）

`Restart-QueueIfNotRunning` 的命令列比對要求出現腳本的**完整絕對路徑**，但用相對路徑啟動（`Set-Location $repo; python -u kaggle_queue.py`）時命令列裡只有裸檔名，比對不到，於是這支腳本**每 15 分鐘都誤判成「沒在跑」而多開一份**。

那些多開的行程一啟動就被 Python 端的 `acquire_lock()` 擋掉、自己退出，**所以沒造成真正的傷害**——但等於每輪白開一個行程，還把 `autorestart.log` 灌滿假的「自動重啟」紀錄，**真的出事時反而看不出來**。

這正是 `acquire_lock()` 註解裡記的 2026-08-18 那次「相對路徑啟動導致漏配」的同一個坑，只是變成每 15 分鐘重演一次。

## 改法

先看 `logs/<腳本名>.lock` 這個單例鎖檔——**那是 Python 端 `acquire_lock()` 用的同一個真相來源**，兩邊用同一個判準才不會各說各話。

- 鎖檔在且 PID 活著 → 略過
- 鎖檔在但 PID 已死（上次沒清乾淨）→ 視為沒在跑，往下走重啟流程。**但不在 PowerShell 這邊刪鎖檔**：`acquire_lock()` 自己會偵測殘留並清掉重搶，由它處理才不會跟正在啟動中的行程搶。
- 鎖檔不存在（例如從沒跑過）→ 退回原本的命令列比對，那段連同防誤判註解原封保留。

## 驗證

- 跑一次修好的腳本，佇列行程數維持 **2 不變**（沒有多開），log 正確記成「已在跑，略過重複啟動」
- 鎖檔名推導確認與實際檔名相符
- PowerShell 語法檢查通過
- **UTF-8 BOM 已確認保留**（中文 .ps1 沒有 BOM 會解析錯誤）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **錯誤修正**
  * 改善系統啟動時的佇列服務檢查，避免服務已在執行時重複啟動。
  * 更準確處理佇列鎖定狀態，降低殘留鎖定資訊造成誤判的情況。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->