### PR TITLE
CodeRabbit：開 request_changes_workflow，讓合併關卡改看意見有沒有真的解決

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,17 @@ reviews:
   auto_review:
     enabled: true
     drafts: false
+  # 2026-08-22 起：main 的分支保護只設了 required_approving_review_count: 1，
+  # 但這個數字不管審核意見從哪來——CodeRabbit 原本只用留言回應，永遠不會被
+  # 算進這個 1，於是「合不合併」變成只看「有沒有人類按過 Approve」，跟
+  # 「CodeRabbit 的意見有沒有真的解決」完全脫鉤。
+  # 打開這個之後：CodeRabbit 有可執行意見時會送出正式的「Request changes」
+  # review（擋住合併），意見全部解決（改完 push，或用 @coderabbitai resolve）
+  # 才會自動改送「Approve」。因為 CodeRabbit 的 GitHub App 對這個 repo 有
+  # write 權限，它送出的 Approve 會被 GitHub 算進 required_approving_review_count，
+  # 不需要人類再按一次——效果變成「CodeRabbit 意見沒解決前不能合併」，
+  # 不是「有人按過就能合併」。
+  request_changes_workflow: true
   path_filters:
     # 結果檔案（.npz/.csv/.json）跟快取的等時線網格不是給人看 diff 的，
     # 審這些只會製造噪音，排除掉。


### PR DESCRIPTION
## 問題

main 的分支保護只設了 `required_approving_review_count: 1`，但這個數字不管審核意見從哪來。CodeRabbit 目前只用留言方式回應 PR（例如「六項全部修正」這類），不是用 GitHub 正式的 Review 機制送出 Approve/Request changes，所以 CodeRabbit 的審核結果永遠不會被算進這個 1。

結果是：「能不能合併」只看「有沒有人類按過 Approve」，跟「CodeRabbit 提出的意見有沒有真的被解決」完全脫鉤——理論上可以有人在 CodeRabbit 意見還沒處理完的情況下就按下 Approve。

## 改動

在 `.coderabbit.yaml` 打開 `reviews.request_changes_workflow: true`：

- CodeRabbit 有可執行意見時，改送出正式的 **Request changes** review（會實際擋住合併），不再只是留言
- 意見全部解決後（改完程式碼 push，或用 `@coderabbitai resolve`），CodeRabbit 自動改送 **Approve**
- 因為 CodeRabbit 的 GitHub App 對這個 repo 有 write 權限，它送出的 Approve 會被 GitHub 算進 `required_approving_review_count`，不需要人類再手動按一次

分支保護規則本身不需要改，`required_approving_review_count: 1` 維持原樣——只是這個 1 現在會由 CodeRabbit 在意見真的解決之後自動補上，而不是靠人工確認「有沒有人按過章」。

## 為什麼這樣改更貼近原本設關卡的用意

這個 repo 之前發生過 41/42 則 CodeRabbit 審查意見沒人回應就被合併的狀況，因此加上了人工 Approve 關卡。但人工關卡只確認「有人按過 Approve」，不確認「意見真的處理了」——按 Approve 本身不會核對 CodeRabbit 講的東西有沒有被修。這個改動讓機器直接核對「意見是不是真的解決」，比人工按章更貼近原本想擋的問題。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **流程改善**
  * 啟用變更請求工作流程。
  * 當存在未解決的可執行意見時，系統會提交「要求變更」；意見全部解決後則提交「核准」。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->