### PR TITLE
queue.txt：清掉 d1_bhac_check 逐字重複的第二筆條目

### DIFF
--- a/queue.txt
+++ b/queue.txt
@@ -279,17 +279,6 @@ d10_config_cd_real|fit_real.py --procs 8 --n-syn 40000 --repeats 5 --configs C,D
 # 是為了讓曲線的斜率看得清楚，不是主張真的有那麼大。
 c19_extra_scatter_sweep|injection_recovery.py --procs 8 --n-syn 40000 --trials 3 --refines 3,3 --scenarios S1 --extra-scatter-sweep 0.05,0.10,0.20,0.30,0.40 --tag _c19_scatter
 
-# ===== 2026-08-19：D1（BHAC15 比較）診斷用途，不是 headline 數字 =====
-# 煙霧測試規模（n_syn=5000, refines=3）在對稱亮端截斷 G>=8.9 下撞牆
-# （f_bin 貼上界 0.950、alpha 貼下界 1.500），詳見 LIMITATIONS.md D1。
-# 這裡用正式規模重跑一次，確認撞牆是蒙地卡羅雜訊還是真實簡併：
-#   若還撞牆 -> 是真實效應，D1 完成條件需要重新評估（放寬範圍或接受
-#              「亮端截斷後的 BHAC15 比較做不出可信數字」這個結論）
-#   若不撞牆 -> 照 D1 原計畫用同一個 --g-bright 跑一次 PARSEC 對照組比較
-# 優先度低於上面所有項目——這是 D1 的可行性確認，不是任何論文數字。
-# 需要 fit_real.py 的 --g-bright 旗標（PR #65 分支，尚未合併進 main）。
-d1_bhac_check|fit_real.py --procs 8 --n-syn 40000 --refines 3,3 --configs C --fix-mh 0.0 --g-bright 8.9 --grid bhac15_gaia_logt7.6-8.4.dat --tag _bhac_check
-
 # ===== 2026-08-20：mass_dependent_fbin（D14 衍生，見 WORK_BOARD.md
 # 「對照 Hobart et al. 2026 的鞏固工作」表）=====
 # synthesise() 裡決定「誰帶伴星」的 Bernoulli(f_bin) 跟主星質量完全獨立，


### PR DESCRIPTION
純文件清理，不影響執行邏輯。

第 255 行與第 291 行是同一個標籤、同一段命令、同一段說明的逐字重複（`grep -c` 確認 repo 裡沒有其他重複標籤）。這個項目已經跑完並記錄在 `results/RESULTS_LOG.md`，`run_queue.py` 靠 `logs/queue_done.txt` 判斷完成與否，第二筆本來就不會被重跑——純粹是文件層級的重複，拿掉不改變任何行為。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件更新**
  * 移除 D1 BHAC15 可行性檢查相關待辦事項與說明。
  * 移除 `--g-bright` 尚未合併的前置註記。
  * 其餘佇列項目維持不變。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->