### PR TITLE
新增 CodeRabbit 審核狀態辨識工具；merge 硬關卡改回不強制擋

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,33 +38,51 @@ CodeRabbit 的審查是**輔助**，不是取代 `WORK_BOARD.md`／PR review 流
 它抓程式面的問題（bug、重複實作、效率），跑不動這個專案的實際計算，
 數字對不對還是要靠 `results/RESULTS_LOG.md` 跟人／其他 agent 交叉核對。
 
-**2026-08-21 起：CodeRabbit 的留言沒回覆／沒 resolve，PR 合併按鈕會被鎖住**
-（起因：查了當時開著的 11 個 PR，42 則 CodeRabbit 留言裡 41 則完全沒人
-回覆——不是有人查過覺得不重要，是真的沒人看過）。機制是兩個設定疊起來：
-`.coderabbit.yaml` 開了 `reviews.request_changes_workflow: true`（CodeRabbit
-會用正式的「Request changes」狀態卡住 PR，直到全部留言 resolved、最新
-commit 已重新審過才自動轉 Approved），加上 GitHub branch protection 把
-main 分支的 required approving review count 提高到至少 1（原本是 0，
-CodeRabbit 卡在 Changes Requested 也不會真的擋合併）。
+**2026-08-21～22：merge 關卡的完整實驗過程（結論見下方最新狀態）**。
+起因：查了當時開著的 11 個 PR，42 則 CodeRabbit 留言裡 41 則完全沒人
+回覆——不是有人查過覺得不重要，是真的沒人看過。2026-08-21 因此加了兩個
+設定疊起來的硬關卡：`.coderabbit.yaml` 開 `reviews.request_changes_workflow:
+true`（CodeRabbit 用正式的「Request changes」狀態卡住 PR，直到全部留言
+resolved、最新 commit 已重新審過才自動轉 Approved），加上 GitHub branch
+protection 把 `required_approving_review_count` 從 0 提高到 1（CodeRabbit
+卡在 Changes Requested 才會真的擋合併；這兩個設定分開套用，前者在版控裡
+跟著 PR 合併生效，後者要另外用 GitHub API／網頁設定套用）。
 
-**這兩個設定不是同一個 PR 套用的**（2026-08-21 CodeRabbit review 要求
-講清楚）：`.coderabbit.yaml` 那個開關在版控裡，跟著 PR 合併生效；
-**branch protection 那一半不在版控裡**，必須另外用 GitHub API／網頁設定
-套用（已於 2026-08-21 套用，`required_approving_review_count = 1`）。
-在 branch protection 套用之前，光有 `request_changes_workflow` **不會**
-真的鎖住合併按鈕——這一點如果搞混，會以為合併了這個 PR 就有保護。
-
-**副作用要知道**：required review count = 1 代表**每個 PR 都需要另一個
-人／帳號按 Approve**，GitHub 不允許自己 approve 自己開的 PR。這是刻意的
-（這個機制的目的就是「不能自己說了算」），但也代表 AI agent 沒辦法自己
-把 PR 合併掉，一定要由人來看過並 approve。
+**這個硬關卡 2026-08-22 已經取消**（`required_approving_review_count`
+改回 0）——**不是因為判斷錯了，是實際跑起來代價太高**：CodeRabbit 免費
+方案的審查額度遠比預期緊（一次處理十幾個 PR 的合併就會整個打光，接著
+好幾個小時額度都沒回來），而 `required_approving_review_count=1` 的硬
+關卡讓「額度用完」直接等於「PR 永久卡住、誰都合併不了」，且每次 merge
+都會讓其他 PR 產生新的 git 衝突，光是解衝突就要重複跑很多輪，體感成本
+遠超過 41/42 留言沒人回這件事本身的損失。**現在的做法是「不強制擋，但
+要清楚可見」**：`request_changes_workflow` 保持開著（CodeRabbit 照常送
+正式 Review，Approved／Changes requested／Commented 三種狀態清楚可辨），
+但 `required_approving_review_count=0`，任何人隨時可以直接按 merge，
+**合併前自行判斷 CodeRabbit 的意見要不要處理**，不是被按鈕鎖死。
 
 **這不是自動修**——CodeRabbit 本身沒有辦法設定成自動觸發 autofix（官方
-文件明講一定要手動下 `@coderabbitai autofix` 或按 checkbox），這個機制
-只保證「沒處理就合併不了」，不保證有人幫你處理。收到 CodeRabbit 留言時
-還是要照這個檔案下面的流程回覆＋resolve（或確認站不住腳就說明理由），
-PR 才會解鎖。如果 CodeRabbit 誤判某則已經處理好的留言、卡住不放，找
+文件明講一定要手動下 `@coderabbitai autofix` 或按 checkbox）。收到
+CodeRabbit 留言，還是要照這個檔案下面的流程回覆＋resolve（或確認站不住
+腳就說明理由）。如果 CodeRabbit 誤判某則已經處理好的留言、卡住不放，找
 不到問題就直接在 GitHub UI 手動 resolve 該討論串。
+
+**「Review completed」是個陷阱，不能只看這個綠燈**（2026-08-22 發現）：
+CodeRabbit 在 commit status 上永遠顯示 `context=CodeRabbit`／
+`description="Review completed"`／`state=success`，**即使它因為額度用完
+（"Review rate limited"）根本沒有送出正式 Review 也一樣**——這個綠燈只
+代表「CodeRabbit 的自動化跑完了」，不代表「真的審過、審查結果可信」，
+兩者混在同一個燈號裡，肉眼從 PR 頁面或 `gh pr checks` 完全分不出來。
+**唯一可靠的判定：拿最後一則正式 Review 的 `commit_id`，跟 PR 目前的
+head SHA 比對**——相等才代表這次 push 真的被審過。已經寫成工具，合併前
+先跑：
+```
+scripts/tools/coderabbit_status.sh <PR 編號...>   # 查指定 PR
+scripts/tools/coderabbit_status.sh                # 查全部 open PR
+```
+輸出會明確標示每個 PR 是「✅ 已審過且核准」「🔴 已審過但還有意見」
+「💬 已審過但只是留言」，還是「⚠ 還沒有針對目前這個 commit 的正式
+review（多半是額度用完被跳過）」——只有前三種才代表 CodeRabbit 真的
+看過目前這次 push，「⚠」那一種不能當「審過沒問題」。
 
 **注意 `@coderabbitai resolve` 的用法**（2026-08-21 CodeRabbit review
 訂正，原本這裡寫錯）：這個指令**必須以 PR 的頂層留言送出**（不是在

--- a/scripts/tools/coderabbit_status.sh
+++ b/scripts/tools/coderabbit_status.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# CodeRabbit 對某個 PR「是不是真的審過目前這次 push」的判定工具。
+#
+# 動機（2026-08-22）：CodeRabbit 在 repo 的 commit status 永遠顯示
+# context=CodeRabbit / description="Review completed" / state=success，
+# 即使它因為額度用完（"Review rate limited"）根本沒有送出正式 Review。
+# 這個 status 只代表「CodeRabbit 的自動化跑完了」，不代表「有審查結果」，
+# 兩者被混在同一個綠燈裡，肉眼從 PR 頁面或 `gh pr checks` 完全分不出來。
+#
+# 唯一可靠的判定：正式 Review（Approve/Request changes/Comment）物件上
+# 帶的 commit_id，是不是等於 PR 目前的 head SHA。
+#   - 相等 -> 這次 push 真的被審過，review 的 state 可信
+#   - 不相等（或完全沒有 review）-> commit status 說完成，但其實沒有
+#     針對目前這個 commit 的審查結果，多半是額度用完，不能當「通過」
+#
+# 用法：
+#   scripts/tools/coderabbit_status.sh 98          # 查單一 PR
+#   scripts/tools/coderabbit_status.sh              # 查目前所有 open PR
+#
+# 需要 gh CLI 已登入，repo 由目前所在目錄的 git remote 決定。
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+
+check_one() {
+  local n="$1"
+  local head_sha status_desc status_state review_json review_state review_commit review_at title
+
+  title=$(gh api "repos/$REPO/pulls/$n" --jq '.title' 2>/dev/null) || {
+    echo "PR #$n：查不到（可能已關閉或合併）"
+    return
+  }
+  head_sha=$(gh api "repos/$REPO/pulls/$n" --jq '.head.sha')
+
+  # commit status：CodeRabbit 自動化本身有沒有跑完（不代表有審查結果）
+  status_state=$(gh api "repos/$REPO/commits/$head_sha/status" \
+    --jq '[.statuses[] | select(.context=="CodeRabbit")] | last | .state // "無"')
+
+  # 真正的審查結果：最後一則 coderabbitai review，帶著它對應的 commit
+  review_json=$(gh api "repos/$REPO/pulls/$n/reviews" \
+    --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | last')
+
+  if [ "$review_json" = "null" ] || [ -z "$review_json" ]; then
+    echo "PR #$n  $title"
+    echo "    HEAD ${head_sha:0:7} ｜ CodeRabbit 自動化狀態=$status_state ｜ ⚠ 從來沒有任何正式 review，不能當已審過"
+    return
+  fi
+
+  review_state=$(gh api "repos/$REPO/pulls/$n/reviews" --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | last | .state')
+  review_commit=$(gh api "repos/$REPO/pulls/$n/reviews" --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | last | .commit_id')
+  review_at=$(gh api "repos/$REPO/pulls/$n/reviews" --jq '[.[] | select(.user.login=="coderabbitai[bot]")] | last | .submitted_at')
+
+  echo "PR #$n  $title"
+  if [ "$review_commit" = "$head_sha" ]; then
+    case "$review_state" in
+      APPROVED)          badge="✅ APPROVED（已審過目前這次 push，意見都解決了）" ;;
+      CHANGES_REQUESTED)  badge="🔴 CHANGES_REQUESTED（已審過目前這次 push，還有意見沒解決）" ;;
+      COMMENTED)          badge="💬 COMMENTED（已審過目前這次 push，是留言型審查，不算正式核准）" ;;
+      *)                  badge="$review_state" ;;
+    esac
+    echo "    HEAD ${head_sha:0:7} ｜ 自動化狀態=$status_state ｜ $badge"
+  else
+    echo "    HEAD ${head_sha:0:7} ｜ 自動化狀態=$status_state ｜ ⚠ 還沒有針對目前這個 commit 的正式 review（上一則 review 是 ${review_commit:0:7}、$review_at，多半是額度用完被跳過，不是「審過沒問題」）"
+  fi
+}
+
+if [ $# -ge 1 ]; then
+  for n in "$@"; do
+    check_one "$n"
+  done
+else
+  for n in $(gh pr list --state open --repo "$REPO" --json number --jq '.[].number'); do
+    check_one "$n"
+  done
+fi


### PR DESCRIPTION
## 背景

`required_approving_review_count=1` 這道硬關卡（2026-08-21 建立）實測代價太高：CodeRabbit 免費額度遠比預期緊，一次處理十幾個 PR 的合併就會整個打光，接著好幾個小時額度回不來，PR 因此永久卡住；且每次 merge 都讓其他還沒合併的 PR 產生新的 git 衝突，光是解衝突就要重複跑很多輪。**已經把 branch protection 的 `required_approving_review_count` 改回 0**（GitHub API 套用，不在版控裡）——現在任何人隨時可以直接按 merge，不再被鎖住。

## 這個 PR 解決的問題

拿掉硬關卡後，使用者提出一個關鍵疑慮：怎麼知道 CodeRabbit 是不是真的審過，而不是額度用完被靜默跳過？

**實測發現一個真的會誤導人的陷阱**：CodeRabbit 的 commit status 永遠顯示 `context=CodeRabbit`／`description="Review completed"`／`state=success`，**即使它因為額度用完（"Review rate limited"）根本沒有送出正式 Review 也一樣**。這個綠燈只代表「CodeRabbit 的自動化跑完了」，不代表「真的審過、結果可信」，兩者混在同一個燈號裡，肉眼從 PR 頁面或 `gh pr checks` 完全分不出來。

**唯一可靠的判定**：拿最後一則正式 Review 的 `commit_id`，跟 PR 目前的 head SHA 比對——相等才代表這次 push 真的被審過。

## 改動

- 新增 `scripts/tools/coderabbit_status.sh`：查指定 PR 或全部 open PR，明確標示每個是「✅ 已審過且核准」「🔴 已審過但還有意見」「💬 已審過但只是留言」，還是「⚠ 還沒有針對目前這個 commit 的正式 review（多半是額度用完被跳過）」。
- `CONTRIBUTING.md` 零之一節同步更新，記錄完整實驗過程（為什麼加硬關卡、為什麼拿掉、現在怎麼判斷）。

## 驗證

在目前 9 個 open PR 上實際跑過，準確反映出哪些真的被審過（如 #102 顯示 APPROVED、#88/#101/#104 顯示 CHANGES_REQUESTED）、哪些只是 status 綠燈但其實沒審到（如 #87/#89/#90/#92/#93/#98/#99，上一則 review 的 commit_id 都是舊的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增狀態查詢工具，可透過 GitHub CLI 檢查指定或所有開啟中的 PR。
  * 顯示自動化檢查狀態及最新正式審查結果，並確認審查是否對應目前版本。
  * 支援辨識核准、要求修改、留言審查，以及尚未完成正式審查的情況。

* **文件**
  * 更新 CodeRabbit 合併流程說明，反映目前的審查與合併規則。
  * 補充狀態查詢工具的使用方式與判讀說明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->