### PR TITLE
科學邏輯審查第二輪：診斷腳本全數查核通過（訂正 D14 路徑錯字）

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -962,7 +962,7 @@ Bernoulli(`f_bin`) 決定誰帶伴星，伴星質量 `m2 = q·m1`（`q ~ q^q_gam
 說明已寫進 `PAPER_OUTLINE.md` 3.4 節、`fit_real.py` 檔頭、
 `pipeline/joint_fit.py` 抽樣段落三處。
 
-**兩種定義差多少（實算）**：`scripts/analysis/system_vs_stellar_mf.py`
+**兩種定義差多少（實算）**：`scripts/diagnostics/system_vs_stellar_mf.py`
 （本次新增，可重跑）用專案實際參數（alpha=2.35、q_gamma=−0.50、
 q_min=0.10、量測窗 0.5–2.5 M☉）做四百萬次蒙地卡羅，把伴星也放進同一個
 量測窗後重做截斷冪律 MLE：stellar MF 比 system MF **陡**，


### PR DESCRIPTION
第二輪科學邏輯審查，涵蓋第一輪（PR #104）沒查過的診斷/輔助腳本：
profile_lowmass.py、profile_outlierfrac.py、inject_lowmass.py、
inject_massdep_fbin.py、measure_overconfidence.py、
scripts/diagnostics/ 底下多支（limepy_radial_crosscheck、
system_vs_stellar_mf、traditional_accounting、
check_white_dwarf_contamination、check_poisson_vs_multinomial、
analyze_lowmass 等）、scripts/tools/concat_radial_final.py、
nbody_setup/analyze_alpha_r.py。

**結果：全部查核通過，沒有新的統計/科學邏輯錯誤**——逐一追蹤實際程式
邏輯（不只讀 docstring），並手算重現關鍵數字核對：
- concat_radial_final.py 重算 r3 的 alpha 值（2.4778/2.4778/2.2778/
  2.3889/2.5000），平均 2.4244、樣本標準差 0.0924、標準誤 0.0413，
  跟已發表數字完全吻合，沒有分片錯位或誤把非獨立樣本當獨立處理的
  問題（A5 那類 bug 這裡沒有重演）
- check_poisson_vs_multinomial.py 的等價證明代數重新推導一次，
  確認 LL 差是與 theta 無關的常數，結論成立
- analyze_lowmass.py 重現 A3 引用的 d(alpha)/d(p) = -0.495 ± 0.111
  與系統偏移 0.248，數字吻合

**修掉的唯一問題**：LIMITATIONS.md D14 條目寫的腳本路徑
（這個目錄根本不存在）應該是
，純文件錯字，不影響任何
已發表數字。

不影響現有任何結果，可以直接合併。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件**
  * 更新診斷腳本的文件路徑，確保使用者可依據正確位置執行 system MF／stellar MF 診斷。
  * 其餘限制說明內容維持不變。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->