### PR TITLE
科學邏輯審查第三輪：多星團/N-body-LIMEPY橋接/資料前處理查核通過（修正 gaia_astrophys.py 寫死路徑）

### DIFF
--- a/scripts/data_prep/gaia_astrophys.py
+++ b/scripts/data_prep/gaia_astrophys.py
@@ -18,6 +18,8 @@ GSP-Spec 則用 RVS 高解析度光譜，金屬量更可靠但只有亮星才有
 """
 from __future__ import annotations
 
+import importlib.util
+import os
 import sys
 from pathlib import Path
 
@@ -25,10 +27,47 @@ import numpy as np
 
 HERE = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(HERE))
-sys.path.insert(0, r"C:\Users\Alber\Claude\gaia-export")
 
 from pipeline.table_compat import Table  # noqa: E402
-import server  # noqa: E402
+
+
+def _load_server():
+    """找到 gaia-export 姊妹專案並匯入它的 server.py，回傳該模組。
+
+    跟 `fetch_gaia.py`／`gaia_radial_velocity.py`／`prep.py` 的
+    `_load_server()` 同一套邏輯：只認環境變數 `GAIA_EXPORT_PATH` 與跟本
+    repo 同層的候選目錄，不 fallback 到任何機器特定的寫死路徑——這支腳本
+    原本寫死 `C:\\Users\\Alber\\Claude\\gaia-export`，換一台機器就會
+    找不到（或更糟：如果那個路徑剛好存在但是別的、過期的 checkout，會被
+    靜默接受，跑出錯的結果卻不報錯）。2026-08-13 CodeRabbit review 已在
+    `gaia_radial_velocity.py`／`fetch_gaia.py`／`prep.py` 修過同一個問題，
+    這支腳本當時漏改，補上跟其他 `scripts/data_prep/` 腳本一致的可攜寫法。
+    """
+    candidates = [os.environ.get("GAIA_EXPORT_PATH")] + [
+        HERE.parent / name for name in ("gaia-dr3-export", "gaia-export")
+    ]
+    for c in candidates:
+        if not c:
+            continue
+        c = Path(c)
+        server_py = c / "server.py"
+        if c.is_dir() and server_py.is_file():
+            sys.path.insert(0, str(c))
+            import server
+            if Path(server.__file__).resolve() != server_py.resolve():
+                spec = importlib.util.spec_from_file_location("server", server_py)
+                server = importlib.util.module_from_spec(spec)
+                sys.modules["server"] = server
+                spec.loader.exec_module(server)
+            return server
+    raise FileNotFoundError(
+        "找不到 gaia-export 專案（含 server.py 的目錄）。"
+        "設定環境變數 GAIA_EXPORT_PATH 指向它，或把它 clone 到跟本 repo 同一層"
+        "（github.com/helmet-png/gaia-dr3-export）。"
+    )
+
+
+server = _load_server()
 
 COLS = [
     "source_id",


### PR DESCRIPTION
第三輪科學邏輯審查，涵蓋前兩輪沒查過的部分：多星團驗證
（cluster_forward_validation.py 等）、N-body/PDMF-LIMEPY 橋接
（nbody_pdmf_*、pdmf_limepy_*、petar_*）、資料前處理
（fetch_gaia.py、build_*_grid.py）、驅動腳本（run_pipeline.py 等）。

**D8（PR #11 多星團正確性問題）核對結果**：讀過 LIMITATIONS.md D8 記載
的四個問題後，逐一在目前 main 上核對，全部確認已經修好：貼牆偵測現在
只允許 dav 這一維、NSS null 值轉 float 後才做 isfinite()、
validate_selection() 有補上紅藍分色檢查、fetch_control_field() 已實作
並接進 main()。D8 狀態本身沒有改動，因為結案條件是「重新用真實資料
跑過」不是「程式碼層面確認修好」，這點需要另外排工，不是這次審查
範圍。

**修掉的唯一問題**：scripts/data_prep/gaia_astrophys.py 裡寫死了
個人路徑 ——跟 2026-08-13 已經
在 fetch_gaia.py／gaia_radial_velocity.py／prep.py 三支姊妹腳本修過的
同一類問題（換機器就找不到，或更糟：悄悄載入到剛好存在但版本不對的
server.py，跑出錯的資料也不會報錯），這支當時漏改了。它的輸出
data/astrophys.csv 是 step5_imf.py 與白矮星/次巨星混入檢查的實際
依賴，不是純裝飾用的腳本。已比照姊妹腳本的作法（GAIA_EXPORT_PATH
環境變數 + 同層資料夾候選，不寫死任何機器路徑）修好。

**其餘全部查核通過**：Plummer 抽樣、維里標度、冪律 MLE、質量分層診斷、
LIMEPY 徑向分箱、卡方/NLL 公式、bootstrap 重抽樣索引、系統-質量橋接、
PeTar 網格的 n_stars = n_systems + n_binaries 逐列手算驗證，全部一致。

不影響任何已發表數字，可以直接合併。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **錯誤修正**
  * 改善 Gaia 天文資料準備流程，支援從設定路徑或常見本機位置尋找所需服務。
  * 啟動前會驗證載入的服務位置，降低載入錯誤。
  * 找不到必要服務時，現在會提供更明確的檔案錯誤訊息。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->