### PR TITLE
本機不再自動重啟計算佇列，改成只用雲端算力

### DIFF
--- a/restart_queue_on_boot.ps1
+++ b/restart_queue_on_boot.ps1
@@ -145,7 +145,11 @@ Write-SelfLog "腳本開始執行"
 
 try {
     Set-Location -Path $repo -ErrorAction Stop
-    Restart-QueueIfNotRunning -ScriptName "run_queue.py" -LogFile "queue_runner8.log"
+    # **2026-08-23 起使用者決定：本機不再跑計算，全部排到雲端**——
+    # 不再自動重啟 run_queue.py（讀 queue.txt 那支本機 8 核佇列）。
+    # 新工作一律排 cloud_queue.txt 交給 cloud_queue.py（GCP/Kaggle）。
+    # 若之後要恢復本機運算，把下面這行的註解拿掉即可，不用改別的地方。
+    # Restart-QueueIfNotRunning -ScriptName "run_queue.py" -LogFile "queue_runner8.log"
     Restart-QueueIfNotRunning -ScriptName "cloud_queue.py" -LogFile "cloud_queue_runner.log"
 }
 catch {


### PR DESCRIPTION
使用者決定：本機不再跑計算，新工作一律排 \`cloud_queue.txt\` 交給 \`cloud_queue.py\`（GCP \`gcp1\` / Kaggle）。

開機/登入自動重啟腳本原本會一併帶起 \`run_queue.py\`（讀 \`queue.txt\` 的本機 8 核佇列），改成只保留 \`cloud_queue.py\`。註解掉而不是刪掉，之後要恢復本機運算直接取消註解即可。

同時已手動停掉這台機器上正在跑的 \`run_queue.py\`（原本在跑 \`radial_r1_final\`，\`fit_real.py\` 有逐次重複的 checkpoint，中止不會丟掉已完成的部分）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **錯誤修正**
  * 調整啟動流程，使用者登入後會自動重新啟動佇列服務。
  * 停用另一項佇列程序的自動重啟，避免不必要的啟動行為。
  * 保留例外處理與失敗時的錯誤回報機制。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->