### PR TITLE
fix: 用 wscript 靜默啟動排程工作，消除主控台視窗閃現

### DIFF
--- a/restart_queue_on_boot.ps1
+++ b/restart_queue_on_boot.ps1
@@ -64,6 +64,14 @@
 # 裡沒排完，先手動搬進 `cloud_queue.txt`（格式完全相同）再交給
 # cloud_queue.py，不要讓兩份佇列檔各自派工。
 
+# **2026-08-24 補充**：工作排程器的兩個工作（M45-QueueWatchdog-15min、
+# M45-QueueRunner-AutoRestart）先前設過 Hidden=true，但那只影響「工作
+# 排程器清單裡看不看得到這個工作」，跟啟動出來的 powershell.exe 主控台
+# 視窗會不會在螢幕上閃一下完全無關，所以每次觸發還是會跳出視窗。改成
+# 由 run_hidden.vbs（同目錄）透過 wscript.exe + WshShell.Run(...,0,False)
+# 呼叫這支腳本，才是真正零閃現的做法；本檔內容不受影響，只是啟動方式
+# 換了一層。
+
 $repo = $PSScriptRoot
 $selfLog = Join-Path $repo "logs\autorestart.log"
 

--- a/run_hidden.vbs
+++ b/run_hidden.vbs
@@ -1,0 +1,8 @@
+' 2026-08-24 新增：Windows 工作排程器直接呼叫 powershell.exe 時，即使工作
+' 本身的 Hidden 屬性設 true，Conhost 還是會在螢幕上短暫閃出一個主控台視窗
+' 再消失（Hidden 只控制工作排程器「工作清單」裡看不看得到這個工作，跟
+' 啟動出來的行程視窗是否可見完全是兩回事）。改用 wscript.exe 執行這支
+' VBScript，用 WshShell.Run 的第二個參數 0（=隱藏視窗）啟動 powershell，
+' 這是 Windows 上真正能做到「零閃現」的標準做法。
+Set objShell = CreateObject("WScript.Shell")
+objShell.Run "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""C:\Users\yutun\Documents\m45-imf-analysis\restart_queue_on_boot.ps1""", 0, False

--- a/run_hidden.vbs
+++ b/run_hidden.vbs
@@ -4,5 +4,24 @@
 ' 啟動出來的行程視窗是否可見完全是兩回事）。改用 wscript.exe 執行這支
 ' VBScript，用 WshShell.Run 的第二個參數 0（=隱藏視窗）啟動 powershell，
 ' 這是 Windows 上真正能做到「零閃現」的標準做法。
+'
+' 路徑用 WScript.ScriptFullName 動態算出，不寫死使用者名稱——這支腳本
+' 之後如果換一台機器或換 checkout 路徑，不用跟著改這個檔案（2026-08-23
+' CodeRabbit review 抓到寫死路徑的問題）。
+'
+' bWaitOnReturn 用 True（等 restart_queue_on_boot.ps1 執行完才返回）：這
+' 支腳本本身只做「查鎖檔/查行程 -> 視情況 Start-Process detached 啟動」，
+' Start-Process 沒有帶 -Wait，所以 restart_queue_on_boot.ps1 本身幾秒內就
+' 會執行完畢，不會因為 run_queue.py／cloud_queue.py 要跑好幾天而被卡住；
+' 等它跑完才能透過 WScript.Quit 把真正的 exit code 往外傳，PowerShell 端
+' 若失敗（-ErrorAction Stop 觸發的例外）才不會被吞掉、工作排程器才看得到
+' 失敗紀錄（2026-08-23 CodeRabbit review 抓到 bWaitOnReturn=False 會吞掉
+' exit code 的問題）。
+Dim objFSO, objShell, scriptDir, ps1Path, cmd, exitCode
+Set objFSO = CreateObject("Scripting.FileSystemObject")
 Set objShell = CreateObject("WScript.Shell")
-objShell.Run "powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""C:\Users\yutun\Documents\m45-imf-analysis\restart_queue_on_boot.ps1""", 0, False
+scriptDir = objFSO.GetParentFolderName(WScript.ScriptFullName)
+ps1Path = objFSO.BuildPath(scriptDir, "restart_queue_on_boot.ps1")
+cmd = "powershell.exe -NoProfile -ExecutionPolicy Bypass -File """ & ps1Path & """"
+exitCode = objShell.Run(cmd, 0, True)
+WScript.Quit exitCode


### PR DESCRIPTION
## 問題

工作排程器兩個工作（M45-QueueWatchdog-15min、M45-QueueRunner-AutoRestart）先前把 `Hidden` 屬性設成 `true`，以為這樣就不會跳出視窗，但 `Hidden` 只影響「工作排程器清單裡看不看得到這個工作」，跟啟動出來的 `powershell.exe` 主控台視窗會不會在螢幕上閃一下完全無關——尤其是螢幕解鎖之後，觸發器補跑時特別容易看到。

## 修法

新增 `run_hidden.vbs`，用 `WshShell.Run(cmd, 0, False)` 啟動 `powershell.exe`（第二參數 0 = 隱藏視窗），這是 Windows 上真正做到零閃現的標準做法。兩個排程工作的動作已改指向這支 vbs（`schtasks /change /tr wscript.exe ...`，本地已套用並驗證 `<Command>`/`<Arguments>` 確實變更）。`restart_queue_on_boot.ps1` 本身邏輯不變，只是換一層啟動方式，補上說明註解。

## 測試

- 本地已用 `schtasks /change` 套用到兩個排程工作，`schtasks /query /xml` 確認 `<Command>wscript.exe</Command>` 生效
- 手動 `schtasks /run` 觸發測試在這個工具的執行環境下卡住不執行到底（跟 `restart_queue_on_boot.ps1` 開頭註解記錄的 2026-08-13 已知問題同一個成因，懷疑是工具本身 session 限制），非本次改動引入的新問題
- 實際效果要等下一次自然觸發（每 15 分鐘／登入時）才能最終確認畫面上完全不閃視窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增隱藏式啟動流程，執行工作排程時不再閃現 PowerShell 主控台視窗。
  * 啟動腳本可依所在目錄自動找到相關 PowerShell 腳本，提升部署彈性。

* **改善**
  * 啟動流程會等待腳本完成，並正確傳遞執行結果。

* **文件**
  * 補充啟動方式與相關行為的說明註解。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->