### PR TITLE
排入 gcp1 剩餘的 D2 門檻（0.5/0.8/0.9）

### DIFF
--- a/cloud_queue.txt
+++ b/cloud_queue.txt
@@ -14,3 +14,8 @@
 # 門檻（0.6、0.7，夾住預設值 0.7）當第一批正式規模測試，觀察真實耗時
 # 後再決定要不要把剩下的 0.5/0.8/0.9 也排進來。
 d2_membership_threshold_p06_p07_retry|scripts/diagnostics/sensitivity_sweep.py|--target membership_threshold --values 0.6,0.7 --procs 4 --n-syn 40000 --refines 3,3||false|gcp1
+
+# 2026-08-24：p0.6/p0.7 那批在 gcp1 上實測 600.4 分鐘（約 10 小時）跑完兩個
+# 門檻，比示範規模外推的「單一門檻 50+ 小時」快非常多，值得把剩下三個
+# 門檻也排進來，湊齊 D2 的完整敏感度掃描（0.5/0.6/0.7/0.8/0.9 五點）。
+d2_membership_threshold_p05_p08_p09|scripts/diagnostics/sensitivity_sweep.py|--target membership_threshold --values 0.5,0.8,0.9 --procs 4 --n-syn 40000 --refines 3,3||false|gcp1


### PR DESCRIPTION
排入 gcp1 剩餘的三個 D2 敏感度掃描門檻（0.5、0.8、0.9），湊齊完整的
五點掃描（0.5/0.6/0.7/0.8/0.9）。

p0.6/p0.7 那批 2026-08-24 02:41 在 gcp1 上完成，實測 600.4 分鐘（約 10
小時）跑完兩個門檻，遠快於 WORK_BOARD.md 記錄的示範規模外推估計（單一
門檻 50+ 小時），值得追加剩下三個門檻。

合併後 `cloud_queue.py` 會在下一輪（60 秒內）自動從 origin/main 同步到
這行新工作並派給 gcp1，不需要重啟。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增完整敏感度掃描任務，涵蓋 0.5、0.8 與 0.9 三種門檻。

* **改善**
  * 擴充掃描佇列，支援更多門檻設定的分析工作。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->