### PR TITLE
把閒置的 Kaggle 帳號用起來：p6b_inject_lowmass_v2 拆分片

### DIFF
--- a/cloud_queue.txt
+++ b/cloud_queue.txt
@@ -44,7 +44,14 @@ p6_lowmass_v3|profile_lowmass.py|--procs 4 --n-syn 40000 --repeats 3 --refines 3
 
 # p6b_inject_lowmass_v2（A1）：p6 低質量段冪次的注入回收驗證，跟
 # p6_lowmass_v3 互補（一個是真實資料擬合，一個是合成資料驗證方法）。
-p6b_inject_lowmass_v2|inject_lowmass.py|--procs 4 --n-syn 40000 --trials 3 --refines 3,3||false|gcp1
+# 2026-08-26：改派到 Kaggle（6 個帳號一直閒置，gcp1 一台機器扛全部 8
+# 項排隊工作太慢）。原本 --trials 3 拆成 inject_lowmass.py 自己文件
+# 建議的標準做法（見該腳本 --trial-offset 說明）：3 個帳號各跑
+# --trials 1 --trial-offset 0/1/2，每片配唯一 --tag 避免互相覆寫，全部
+# 跑完後沿 axis=0 依 offset 由小到大串接、等於一次跑完 --trials 3。
+p6b_inject_lowmass_v2_t0|inject_lowmass.py|--procs 4 --n-syn 40000 --trials 1 --trial-offset 0 --refines 3,3 --tag _p6b_v2_kaggle_t0||false|justinlan11
+p6b_inject_lowmass_v2_t1|inject_lowmass.py|--procs 4 --n-syn 40000 --trials 1 --trial-offset 1 --refines 3,3 --tag _p6b_v2_kaggle_t1||false|teammate2
+p6b_inject_lowmass_v2_t2|inject_lowmass.py|--procs 4 --n-syn 40000 --trials 1 --trial-offset 2 --refines 3,3 --tag _p6b_v2_kaggle_t2||false|helmetalbert
 
 # mass_dependent_fbin（D14 衍生）：雙星比例是否隨質量變化，contrast
 # 掃 0.0/0.15/0.30（腳本內建，不用額外旗標指定），contrast=0 是必要


### PR DESCRIPTION
6 個 Kaggle 帳號從 D2 掃描完之後就一直閒置，`cloud_queue.txt` 裡的 8 項全部指定給 `gcp1`，等於一台機器單線程扛全部工作。

把 `p6b_inject_lowmass_v2` 拆成 `inject_lowmass.py` 自己文件建議的標準3 分片做法（`--trials 1 --trial-offset 0/1/2`，各配唯一 `--tag`），分給 `justinlan11`／`teammate2`／`helmetalbert` 三個帳號平行跑。跟 gcp1 佇列並行，不是重複算力——是同一件事拆開跑更快。

全部三片跑完後需要手動沿 axis=0 依 offset 由小到大串接才等於一次跑完 `--trials 3`（比照之前 radial_r2 分片串接的做法）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 低品質資料段的注入回收工作改由三個平行工作執行，以提升處理效率。
  * 每次工作使用獨立的試驗設定與識別標籤，避免結果混淆。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->