### PR TITLE
用起閒置的 3 個 Kaggle 帳號跑 BP15/BP20 配對比較

### DIFF
--- a/cloud_queue.txt
+++ b/cloud_queue.txt
@@ -54,3 +54,17 @@ mass_dependent_fbin|inject_massdep_fbin.py|--procs 4 --n-syn 40000 --trials 3 --
 # configCD_real_data_compare（D10）：真實資料上比較 config C／D 的
 # alpha 一致性，目前只在合成資料上驗證過。
 configcd_real_data_compare|fit_real.py|--configs C,D --repeats 5 --procs 4 --n-syn 40000 --refines 3,3||false|gcp1
+
+# bp15_bp20_paired_comparison（D12）：account5／account6／account7 三個
+# Kaggle 帳號原本閒置，用來跑 results/bp15_formal_paired_dispatch.json
+# 已經生成好的 10 個 job tag 裡的前 3 組配對（offset 0/1/2）。每組必須
+# BP20／BP15 都跑完才算一組有效配對（彙整器 fail-closed，缺配對就拒算
+# 平均），所以同一個 offset 的兩項排給同一個帳號依序執行。剩下 offset
+# 3／4 等這批帳號有空再排。BP15 那半邊需要額外的隔離輸入檔（--members-file
+# 等三個旗標指到的檔案），已經列進第 4 欄讓 cloud_queue.py 一併同步。
+bp20_formal_40k_rep0|fit_real.py|--procs 4 --n-syn 40000 --repeats 1 --repeat-offset 0 --configs C --refines 3,3 --grid parsec_v2.0_gaiaEDR3_logt7.7-8.3s0.05_mh-0.6-0.6s0.05.dat --tag _bp20_formal_40k_rep0|measure_overconfidence.py,injection_recovery.py|false|account5
+bp15_formal_40k_rep0|fit_real.py|--procs 4 --n-syn 40000 --repeats 1 --repeat-offset 0 --configs C --refines 3,3 --grid parsec_v2.0_gaiaEDR3_logt7.7-8.3s0.05_mh-0.6-0.6s0.05.dat --tag _bp15_formal_40k_rep0 --members-file cmd_members_bp15_smoke.csv --errmodel-file errmodel_bp15_smoke.npz --selection-file selection_bp15_smoke.npz|measure_overconfidence.py,injection_recovery.py,results/cmd_members_bp15_smoke.csv,results/errmodel_bp15_smoke.npz,results/selection_bp15_smoke.npz|false|account5
+bp20_formal_40k_rep1|fit_real.py|--procs 4 --n-syn 40000 --repeats 1 --repeat-offset 1 --configs C --refines 3,3 --grid parsec_v2.0_gaiaEDR3_logt7.7-8.3s0.05_mh-0.6-0.6s0.05.dat --tag _bp20_formal_40k_rep1|measure_overconfidence.py,injection_recovery.py|false|account6
+bp15_formal_40k_rep1|fit_real.py|--procs 4 --n-syn 40000 --repeats 1 --repeat-offset 1 --configs C --refines 3,3 --grid parsec_v2.0_gaiaEDR3_logt7.7-8.3s0.05_mh-0.6-0.6s0.05.dat --tag _bp15_formal_40k_rep1 --members-file cmd_members_bp15_smoke.csv --errmodel-file errmodel_bp15_smoke.npz --selection-file selection_bp15_smoke.npz|measure_overconfidence.py,injection_recovery.py,results/cmd_members_bp15_smoke.csv,results/errmodel_bp15_smoke.npz,results/selection_bp15_smoke.npz|false|account6
+bp20_formal_40k_rep2|fit_real.py|--procs 4 --n-syn 40000 --repeats 1 --repeat-offset 2 --configs C --refines 3,3 --grid parsec_v2.0_gaiaEDR3_logt7.7-8.3s0.05_mh-0.6-0.6s0.05.dat --tag _bp20_formal_40k_rep2|measure_overconfidence.py,injection_recovery.py|false|account7
+bp15_formal_40k_rep2|fit_real.py|--procs 4 --n-syn 40000 --repeats 1 --repeat-offset 2 --configs C --refines 3,3 --grid parsec_v2.0_gaiaEDR3_logt7.7-8.3s0.05_mh-0.6-0.6s0.05.dat --tag _bp15_formal_40k_rep2 --members-file cmd_members_bp15_smoke.csv --errmodel-file errmodel_bp15_smoke.npz --selection-file selection_bp15_smoke.npz|measure_overconfidence.py,injection_recovery.py,results/cmd_members_bp15_smoke.csv,results/errmodel_bp15_smoke.npz,results/selection_bp15_smoke.npz|false|account7


### PR DESCRIPTION
`account5`／`account6`／`account7` 三個 Kaggle 帳號從 D2 掃描完就一直閒置。`bp15_bp20_paired_comparison`（D12）的派工前置檢查早就做完了（`prepare_bp15_paired_dispatch.py` 已生成 10 個 job tag、82.2 MB payload 已驗證可讀），卡住的原因只是本機一直沒有 Kaggle 憑證送不出去——現在 `cloud_queue.py` 已經有憑證了，排前 3 組配對（offset 0/1/2）用起這三個帳號。

同一個 offset 的 BP20／BP15 兩項排給同一個帳號依序執行——彙整器（`summarize_bp15_formal_paired.py`）是 fail-closed 設計，缺任何一半配對就拒算平均，所以要確保同一組配對真的在同一個帳號上跑完。BP15 那半邊需要額外的隔離輸入檔（`--members-file`／`--errmodel-file`／`--selection-file` 指到的檔案），已經列進第 4 欄的額外檔案清單。剩下 offset 3／4 等這批帳號有空再排。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增 BP15 與 BP20 的配對比較批次，涵蓋多組偏移量設定。
  - BP15 批次支援隔離輸入檔案與同步檔案清單，提升資料處理的一致性。
  - 各批次採用統一的程序數、合成樣本數與網格設定，方便比較結果並確保執行條件一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->