### PR TITLE
CONTRIBUTING.md：編輯受管控檔案前先確認規則版本是最新的

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,20 @@ Claude，先讀 `CLAUDE.md`；這份是通用規則，兩者都要遵守。
 疑點，不要用猜的。開始時在 `WORK_BOARD.md` 認領一行。完整格式規則見
 零之四。
 
+**格式規則本身會變，讀過一次不等於現在還適用**：這份文件（跟
+`AGENTS.md`）記的是格式與流程規則，不是任務內容，所以不像
+`WORK_BOARD.md` 那樣「認領過就不會被別人動」——任何 session 都可能
+在你上次讀過之後修改這裡的規則（例如重新設計 `WORK_BOARD.md` 的欄位
+格式）。動手編輯 `WORK_BOARD.md`／`WORK_BOARD_DONE.md`／
+`LIMITATIONS.md`／`QUEUE_ALERTS.md` 這類受規則管控的檔案前，先確認
+你手上這份 `CONTRIBUTING.md` 是不是最新版：`git fetch origin main`
+後比對本機 `CONTRIBUTING.md` 的 commit（`git log -1 --format=%H --
+CONTRIBUTING.md`）跟 `origin/main` 的是否一致；不一致就用
+`git diff <你上次讀到的 commit>..origin/main -- CONTRIBUTING.md`
+只看差異部分（便宜，不用整份重讀），確認相關章節有沒有變。長對話
+中途也一樣——不要憑對話稍早讀過的規則操作，過程中可能已經有別的
+PR 合併改了格式。
+
 ---
 
 ## 零之一、自動 PR 審查——CodeRabbit（免費，公開 repo 自動適用）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,19 +28,22 @@ Claude，先讀 `CLAUDE.md`；這份是通用規則，兩者都要遵守。
 疑點，不要用猜的。開始時在 `WORK_BOARD.md` 認領一行。完整格式規則見
 零之四。
 
-**格式規則本身會變，讀過一次不等於現在還適用**：這份文件（跟
-`AGENTS.md`）記的是格式與流程規則，不是任務內容，所以不像
+**格式規則本身會變，讀過一次不等於現在還適用**：`CONTRIBUTING.md` 跟
+`AGENTS.md` 記的是格式與流程規則，不是任務內容，所以不像
 `WORK_BOARD.md` 那樣「認領過就不會被別人動」——任何 session 都可能
 在你上次讀過之後修改這裡的規則（例如重新設計 `WORK_BOARD.md` 的欄位
 格式）。動手編輯 `WORK_BOARD.md`／`WORK_BOARD_DONE.md`／
-`LIMITATIONS.md`／`QUEUE_ALERTS.md` 這類受規則管控的檔案前，先確認
-你手上這份 `CONTRIBUTING.md` 是不是最新版：`git fetch origin main`
-後比對本機 `CONTRIBUTING.md` 的 commit（`git log -1 --format=%H --
-CONTRIBUTING.md`）跟 `origin/main` 的是否一致；不一致就用
-`git diff <你上次讀到的 commit>..origin/main -- CONTRIBUTING.md`
-只看差異部分（便宜，不用整份重讀），確認相關章節有沒有變。長對話
-中途也一樣——不要憑對話稍早讀過的規則操作，過程中可能已經有別的
-PR 合併改了格式。
+`LIMITATIONS.md`／`QUEUE_ALERTS.md` 這類受規則管控的檔案前，兩份規則
+文件都要各自確認是不是最新版：`git fetch origin main` 後對
+`CONTRIBUTING.md` 與 `AGENTS.md` 各自比對本機 commit（`git log -1
+--format=%H -- <檔名>`）跟 `origin/main` 的是否一致；不一致就用
+`git diff <你上次讀到的 commit>..origin/main -- <檔名>` 只看差異部分
+（便宜，不用整份重讀），確認相關章節有沒有變。**只比對已 commit 的
+版本不夠**：工作目錄裡若還有這兩份文件尚未 commit 的修改（`git status
+--short -- CONTRIBUTING.md AGENTS.md` 看得出來），commit hash 比對
+不到那些改動，這種情況要直接讀工作目錄裡的當前檔案內容，不能只信
+commit hash。長對話中途也一樣——不要憑對話稍早讀過的規則操作，過程
+中可能已經有別的 PR 合併改了格式。
 
 ---
 


### PR DESCRIPTION
起因：本次 session 編輯 \`WORK_BOARD.md\` 時沿用了對話稍早讀到的舊版格式規則，沒發現 PR #127 已經重新設計過欄位格式與寫法禁令（不加時間戳細節、不加不必要的形容詞、完成狀態不留在 \`WORK_BOARD.md\`），導致新加的內容違反現行規則，事後才補修（見 #134、#128 的後續 commit）。

補上明確提醒：\`CONTRIBUTING.md\`／\`AGENTS.md\` 是規則文件，不是任務內容，不會像 \`WORK_BOARD.md\` 那樣「認領過就不會被別人動」——任何 session 都可能在你讀過之後修改規則本身。動手編輯受規則管控的檔案前，先確認本機 \`CONTRIBUTING.md\` 是不是最新版（\`git fetch\` + 比對 commit hash），不一致就只看差異部分，不用整份重讀，省 token 同時避免用過期規則操作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文件**
  * 更新貢獻指南，新增共用文件編輯前的版本同步與差異檢查規則。
  * 長時間進行對話或工作時，需重新確認最新規範，確保遵循目前版本。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->