### PR TITLE
修好 Smart App Control 擋掉 kaggle.exe：改用 python -m kaggle

### DIFF
--- a/kaggle_accounts.py
+++ b/kaggle_accounts.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
@@ -40,6 +41,36 @@ _ARM64_SCRIPTS = (Path.home() / "AppData" / "Local" / "Python" /
                   "pythoncore-3.14-arm64" / "Scripts")
 if _ARM64_SCRIPTS.exists() and str(_ARM64_SCRIPTS) not in os.environ.get("PATH", ""):
     os.environ["PATH"] = f"{_ARM64_SCRIPTS}{os.pathsep}{os.environ.get('PATH', '')}"
+
+
+# 呼叫 Kaggle CLI 的指令前綴。**不要寫死成 ["kaggle", ...]**
+# （2026-08-26，這個坑實際擋掉了整批派工）：
+#
+# Windows 的 Smart App Control（智慧型應用程式控制）開啟時，會擋掉
+# 「沒有數位簽章、或簽章知名度不足」的執行檔。`kaggle.exe` 是 pip 安裝時
+# 自動產生的 wrapper，正好屬於這一類，於是 `subprocess.run(["kaggle", ...])`
+# 直接噴 `OSError: [WinError 4551] 應用程式控制原則已封鎖此檔案`。
+#
+# **症狀很容易誤判成別的問題**：派工器推得出去工作，但每次查狀態就拋
+# 例外、保留槽位、下一輪重試，於是所有 Kaggle 帳號看起來都「卡在檢查
+# 中」、永遠不會完成，log 裡只有一長串看起來跟 Kaggle 無關的
+# CreateProcess traceback。2026-08-26 PR #136／#139 合併後，9 個 Kaggle
+# 工作全部卡在這裡。
+#
+# 解法是改用 `python -m kaggle`：跑的是 python.exe（本來就在允許清單裡，
+# 否則這支程式自己也起不來），Kaggle 套件本身是純 Python 模組、不受執行檔
+# 簽章政策管轄。功能與參數跟 kaggle.exe 完全相同——kaggle.exe 本來就只是
+# 這個模組的一層薄殼。
+#
+# **刻意不要求使用者關掉 Smart App Control**：它一旦關閉，就無法在不重灌
+# Windows 的情況下重新開啟。為了一支工具犧牲整台機器的執行檔防護不划算，
+# 而且換一台機器（例如隊友的）一樣會再踩到，改程式才是一勞永逸的修法。
+#
+# 用 `sys.executable` 而不是字面的 "python"：確保用的是「現在正在跑這支
+# 程式的那個 Python」。這跟上面 ARM64 PATH 那段處理的是同一類問題——
+# 這台機器上同時存在好幾個 Python 版本，裝了 kaggle 套件的不一定是 PATH
+# 上排最前面的那一個。
+KAGGLE_CMD = [sys.executable, "-m", "kaggle"]
 
 
 def load_accounts() -> dict[str, dict[str, str]]:

--- a/kaggle_queue.py
+++ b/kaggle_queue.py
@@ -318,7 +318,7 @@ def probe_kernel_status(kid: str, env: dict) -> str:
 
     回傳 "running"／"complete"／"error"／"cancelled"／"missing"／"unknown"。
     """
-    r = run(["kaggle", "kernels", "status", kid], env=env)
+    r = run([*kaggle_accounts.KAGGLE_CMD, "kernels", "status", kid], env=env)
     text = (r.stdout + r.stderr).strip()
     if r.returncode == 0 and "has status" in text:
         if "COMPLETE" in text:
@@ -442,7 +442,7 @@ def recover_running_slots(accounts: dict, envs: dict) -> dict[str, dict | None]:
 
 def push_kernel_only(work_dir: Path, env: dict) -> bool:
     """只重推 kernel，沿用該帳號 work_dir 裡已經上傳過的 dataset。"""
-    r = run(["kaggle", "kernels", "push", "-p", str(work_dir)], env=env)
+    r = run([*kaggle_accounts.KAGGLE_CMD, "kernels", "push", "-p", str(work_dir)], env=env)
     print(r.stdout[-1500:], flush=True)
     if r.returncode != 0:
         print(r.stderr[-1500:], flush=True)
@@ -460,7 +460,7 @@ def pull(kid: str, label: str, env: dict) -> bool:
     """
     out = HERE / "kaggle_results" / label
     out.mkdir(parents=True, exist_ok=True)
-    r = run(["kaggle", "kernels", "output", kid, "-p", str(out)], env=env)
+    r = run([*kaggle_accounts.KAGGLE_CMD, "kernels", "output", kid, "-p", str(out)], env=env)
     if r.returncode != 0:
         print(f"  下載 {kid} 輸出失敗（rc={r.returncode}）："
               f"{(r.stderr or r.stdout)[-500:]}", flush=True)

--- a/kaggle_queue.py
+++ b/kaggle_queue.py
@@ -45,6 +45,26 @@ from pathlib import Path
 import kaggle_accounts
 from run_queue import _pid_alive  # 單例鎖用，見 acquire_lock() 的說明
 
+def _safe_print(text: str) -> None:
+    """print()，但不會因為主控台編碼印不出某個字元就整個爆掉。
+
+    **2026-08-26 實際發生的事故**：Kaggle CLI 的輸出裡混了一個這台中文
+    Windows 主控台（cp950／Big5）編碼不出來的字元（U+0135 ĵ，帶抑揚符
+    的拉丁字母，猜測來自某個套件版本字串或使用者名稱），`print()` 直接
+    拋 `UnicodeEncodeError`，被 `cloud_queue.py` 的外層 except 接住當成
+    「這個工作啟動失敗」——但實際上 `kaggle_sync.py push` 那個子行程早就
+    跑完了，kernel 可能已經成功建立，只是**印結果訊息**這一步在失敗。
+    誤判成失敗會導致重試，可能對同一個帳號重複推送。
+
+    跟 `run_queue.py`（讀 `tasklist` 輸出）、`kaggle_sync.py`（子行程要用
+    UTF-8 輸出）的既有做法同一個精神：這台機器的主控台編碼不可信任，
+    印任何可能含任意 Unicode 的外部輸出前都要先擋一次，不能假設能印。
+    印不出的字元換成 `?`（`errors="replace"`），保留其餘內容可讀。
+    """
+    enc = sys.stdout.encoding or "utf-8"
+    print(text.encode(enc, errors="replace").decode(enc), flush=True)
+
+
 HERE = Path(__file__).resolve().parent
 QUEUE = HERE / "kaggle_queue.txt"
 DONE = HERE / "logs" / "kaggle_queue_done.txt"
@@ -286,10 +306,10 @@ def push(item: dict, account_name: str) -> tuple[bool, str, Path]:
     if item["minimal"]:
         cmd += ["--minimal"]
     r = run(cmd)
-    print(r.stdout[-3000:], flush=True)
+    _safe_print(r.stdout[-3000:])
     if r.returncode != 0:
-        print("--- push 失敗 stderr ---", flush=True)
-        print(r.stderr[-3000:], flush=True)
+        _safe_print("--- push 失敗 stderr ---")
+        _safe_print(r.stderr[-3000:])
     accounts = kaggle_accounts.load_accounts()
     username = accounts[account_name]["username"]
     kid = f"{username}/m45-imf-run-{slug}"
@@ -443,9 +463,9 @@ def recover_running_slots(accounts: dict, envs: dict) -> dict[str, dict | None]:
 def push_kernel_only(work_dir: Path, env: dict) -> bool:
     """只重推 kernel，沿用該帳號 work_dir 裡已經上傳過的 dataset。"""
     r = run([*kaggle_accounts.KAGGLE_CMD, "kernels", "push", "-p", str(work_dir)], env=env)
-    print(r.stdout[-1500:], flush=True)
+    _safe_print(r.stdout[-1500:])
     if r.returncode != 0:
-        print(r.stderr[-1500:], flush=True)
+        _safe_print(r.stderr[-1500:])
     return r.returncode == 0
 
 

--- a/kaggle_sync.py
+++ b/kaggle_sync.py
@@ -304,7 +304,7 @@ def wait_dataset_ready(dataset_id: str, env: dict, timeout_s: int = 180,
     t0 = time.time()
     first_ready_at = None
     while time.time() - t0 < timeout_s:
-        r = subprocess.run(["kaggle", "datasets", "status", dataset_id],
+        r = subprocess.run([*kaggle_accounts.KAGGLE_CMD, "datasets", "status", dataset_id],
                            capture_output=True, text=True,
                            encoding="utf-8", errors="replace", env=env)
         status = (r.stdout + r.stderr).strip()
@@ -338,19 +338,19 @@ def cmd_push(a):
     dataset_id = make_dataset_metadata(slug, username, work_dir)
     # 先建/更新 dataset
     exists = subprocess.run(
-        ["kaggle", "datasets", "status", dataset_id],
+        [*kaggle_accounts.KAGGLE_CMD, "datasets", "status", dataset_id],
         capture_output=True, text=True, env=env)
     if exists.returncode == 0:
-        run(["kaggle", "datasets", "version", "-p", str(work_dir),
+        run([*kaggle_accounts.KAGGLE_CMD, "datasets", "version", "-p", str(work_dir),
              "-m", "update", "-r", "zip"], env=env)
     else:
-        run(["kaggle", "datasets", "create", "-p", str(work_dir),
+        run([*kaggle_accounts.KAGGLE_CMD, "datasets", "create", "-p", str(work_dir),
              "-r", "zip"], env=env)
     wait_dataset_ready(dataset_id, env)
 
     kernel_id = make_kernel(a.script, a.args, dataset_id, username, slug,
                             extra_files, work_dir, minimal=a.minimal)
-    run(["kaggle", "kernels", "push", "-p", str(work_dir)], env=env)
+    run([*kaggle_accounts.KAGGLE_CMD, "kernels", "push", "-p", str(work_dir)], env=env)
     print(f"\nKERNEL_ID={kernel_id}", flush=True)
     print(f"追蹤：https://www.kaggle.com/code/{kernel_id.split('/')[-1]}")
     print(f"查狀態：python kaggle_sync.py status --kernel {kernel_id} "
@@ -359,14 +359,14 @@ def cmd_push(a):
 
 def cmd_status(a):
     _, _, env = resolve_account(a.account)
-    run(["kaggle", "kernels", "status", a.kernel], env=env)
+    run([*kaggle_accounts.KAGGLE_CMD, "kernels", "status", a.kernel], env=env)
 
 
 def cmd_pull(a):
     _, _, env = resolve_account(a.account)
     out = HERE / "kaggle_results" / Path(a.kernel).name
     out.mkdir(parents=True, exist_ok=True)
-    run(["kaggle", "kernels", "output", a.kernel, "-p", str(out)], env=env)
+    run([*kaggle_accounts.KAGGLE_CMD, "kernels", "output", a.kernel, "-p", str(out)], env=env)
     print(f"結果存到 {out}")
 
 


### PR DESCRIPTION
PR #136／#139 合併後，9 個 Kaggle 工作全部卡住不動。查 log 發現每次查
工作狀態都拋同一個例外：

    OSError: [WinError 4551] 應用程式控制原則已封鎖此檔案。

原因是這台機器的 Windows Smart App Control（智慧型應用程式控制）是開啟
狀態（VerifiedAndReputablePolicyState = 1），它會擋掉沒有數位簽章、或 簽章知名度不足的執行檔。`kaggle.exe` 是 pip 安裝時自動產生的 wrapper，
正好屬於這一類。

症狀容易誤判：派工器推得出去工作，但每次 probe_slot() 查狀態就拋例外、
保留槽位、下一輪重試，於是六個帳號看起來都「卡在檢查中」永遠不完成，
log 裡只有一長串看起來跟 Kaggle 無關的 CreateProcess traceback。

修法是改用 `python -m kaggle`：跑的是 python.exe（本來就在允許清單裡， 否則這些腳本自己也起不來），Kaggle 套件本身是純 Python 模組、不受執行檔
簽章政策管轄。參數與行為跟 kaggle.exe 完全相同——kaggle.exe 本來就只是
這個模組的一層薄殼。

- kaggle_accounts.py：新增 KAGGLE_CMD = [sys.executable, "-m", "kaggle"]， 放在這裡是因為 kaggle_queue.py 與 kaggle_sync.py 都已經匯入這支，跟既有 的 ARM64 PATH 修正同一個位置、同一類問題（都是「怎麼正確叫到 kaggle」）。 用 sys.executable 而非字面 "python"，確保用的是裝了 kaggle 套件的那個 Python——這台機器同時有好幾個版本。
- kaggle_queue.py（3 處）、kaggle_sync.py（7 處）：所有 ["kaggle", ...] 改成 [*kaggle_accounts.KAGGLE_CMD, ...]。

刻意不採「請使用者關掉 Smart App Control」這條路：它一旦關閉就無法在不
重灌 Windows 的情況下重新開啟，為一支工具犧牲整台機器的執行檔防護不划算，
而且換一台機器（例如隊友的）一樣會再踩到，改程式才是一勞永逸。

已驗證：三支檔案 py_compile 通過；實際執行
`subprocess.run([*KAGGLE_CMD, "--version"])` 回傳 returncode 0（不再被 封鎖，只剩正常的「需要認證」訊息，認證由呼叫端的 env 提供）。