### PR TITLE
fix: kaggle 派工/上傳流程的 4 個安全性與可靠性問題（PR #140 回溯審查）

### DIFF
--- a/kaggle_accounts.py
+++ b/kaggle_accounts.py
@@ -88,8 +88,15 @@ def load_accounts() -> dict[str, dict[str, str]]:
                 f"多人使用：複製 {EXAMPLE_FILE.name} 改名成 "
                 f"{ACCOUNTS_FILE.name}，每個帳號去 kaggle.com/settings/api "
                 f"按 Generate New Token 貼進去。")
-        # 舊流程沒有登記 username，用 kaggle.json 裡的（若存在）或留空 ——
-        # 留空只會影響組 ID 時的顯示，實際認證只看 token。
+        # 舊流程沒有登記 username，用 kaggle.json 裡的（若存在）。
+        # **不能留空**（2026-08-26 CodeRabbit 回溯審查抓到）：username 不只
+        # 影響顯示，kaggle_sync.py 的 make_dataset_metadata()／make_kernel()
+        # 直接拿它組 dataset/kernel ID（f"{username}/m45-imf-{slug}"）。
+        # 留空會組出 "/m45-imf-xxx" 這種缺 owner 前綴的 ID，Kaggle CLI 在
+        # datasets create 才會失敗，而且錯誤訊息看不出是 username 缺失。
+        # 這支模組的 docstring 明講「不需要下載 kaggle.json」，所以「只有
+        # access_token、沒有 kaggle.json」是真的會發生的狀態，這裡要直接
+        # 擋下來、給可行動的錯誤訊息，而不是留給下游一個查不出原因的失敗。
         username = ""
         kj = Path.home() / ".kaggle" / "kaggle.json"
         if kj.exists():
@@ -98,6 +105,12 @@ def load_accounts() -> dict[str, dict[str, str]]:
                     "username", "")
             except (json.JSONDecodeError, OSError):
                 pass
+        if not username:
+            raise ValueError(
+                f"找到 {token_path} 但無法取得 username（{kj} 不存在，或"
+                f"存在但沒有 username 欄位）。組 dataset/kernel ID 需要"
+                f"username，請改用 {ACCOUNTS_FILE.name}（複製 "
+                f"{EXAMPLE_FILE.name}）明確登記 username 與 token。")
         return {"default": {"username": username,
                             "token": token_path.read_text(encoding="utf-8").strip()}}
 

--- a/kaggle_queue.py
+++ b/kaggle_queue.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import time
@@ -291,11 +292,20 @@ def run(cmd: list[str], env: dict | None = None) -> subprocess.CompletedProcess:
                           env=env)
 
 
-def push(item: dict, account_name: str) -> tuple[bool, str, Path]:
+def push(item: dict, account_name: str, username: str) -> tuple[bool, str, Path]:
     """呼叫 kaggle_sync.py push（用獨立行程，出例外不會拖垮這支常駐執行器）。
 
     回傳 (是否成功, kernel id, work_dir)。kid 用跟 kaggle_sync.py 相同的
     公式算出來，而不是解析它印出的文字 —— 少一層字串解析就少一種脆弱點。
+
+    **username 由呼叫端傳入，這裡不自己重新 load_accounts()**（2026-08-26
+    CodeRabbit 回溯審查抓到）：main() 開始時已經載入過一次 accounts；
+    docstring 明講「執行中可以把新工作追加到 kaggle_queue.txt 末端」，
+    使用者也可能在執行中編輯 kaggle_accounts.json——若該檔案當下正好是
+    半寫入狀態，這裡重新 json.loads() 會拋 JSONDecodeError，而 main()
+    的主迴圈沒有包 try/except，整支常駐執行器就會直接掛掉，所有槽位裡
+    正在跑的 kernel 沒人追蹤。就算沒撞到半寫入，執行中途檔案內容改變，
+    也可能讓這裡算出的 kid 跟實際 push 出去的 kernel 對不上。
     """
     slug = item["label"].replace("_", "-")
     cmd = [sys.executable, "kaggle_sync.py", "push",
@@ -310,8 +320,6 @@ def push(item: dict, account_name: str) -> tuple[bool, str, Path]:
     if r.returncode != 0:
         _safe_print("--- push 失敗 stderr ---")
         _safe_print(r.stderr[-3000:])
-    accounts = kaggle_accounts.load_accounts()
-    username = accounts[account_name]["username"]
     kid = f"{username}/m45-imf-run-{slug}"
     work_dir = HERE / "kaggle_work" / account_name
     return r.returncode == 0, kid, work_dir
@@ -477,8 +485,17 @@ def pull(kid: str, label: str, env: dict) -> bool:
     不會再重試，等於一次網路中斷就永久丟掉一個已經算完的 kernel 的結果。
     這在這個專案不是假設性風險：rep5 的下載就曾經因為 IncompleteRead 中斷
     過，當時是人工發現才補拉的。
+
+    **下載前先清空 `out`**（2026-08-26 CodeRabbit 回溯審查抓到）：原本只
+    `mkdir(exist_ok=True)`，不會清掉上一次重試留下的舊檔案。Kaggle CLI
+    下載時用輸出檔案原始檔名、沒有明確的覆寫選項，若重試這次跟上次的
+    輸出檔名不同，舊檔案會一直留著。`is_mount_race_failure()` 會掃描
+    這個目錄底下所有 `*.log`，殘留的舊檔案可能讓它把這次的真腳本錯誤
+    誤判成掛載時序問題，造成不必要的額外重試、浪費 Kaggle quota。
     """
     out = HERE / "kaggle_results" / label
+    if out.exists():
+        shutil.rmtree(out)
     out.mkdir(parents=True, exist_ok=True)
     r = run([*kaggle_accounts.KAGGLE_CMD, "kernels", "output", kid, "-p", str(out)], env=env)
     if r.returncode != 0:
@@ -531,6 +548,21 @@ def main() -> None:
         # 第 2、3 次重試——MAX_PUSH_RETRIES 形同虛設。
         retryable_push_failure = False
 
+        # 0.5) 指定了不存在帳號的工作，永遠塞不進任何槽位（下面 1) 的迴圈
+        # 只會把工作派給 `it["account"] in (None, name)` 的槽位）——這個
+        # 狀態是可以到達的：kaggle_accounts.load_accounts() 會在 token 看
+        # 起來像佔位字串時略過該帳號、只印一行警告，佇列裡卻可能還指定
+        # 著那個帳號名稱。不擋下來的話，這個工作會永遠留在 pending，迴圈
+        # 尾端的結束條件（not pending）永遠不成立，執行器每 60 秒空轉一次，
+        # 不印任何診斷訊息、也不會結束（2026-08-26 CodeRabbit 回溯審查抓到）。
+        unknown = [it for it in pending
+                   if it["account"] is not None and it["account"] not in accounts]
+        for it in unknown:
+            print(f"錯誤：{it['label']} 指定的帳號 {it['account']!r} 不在"
+                  f"登記檔裡，可用帳號：{list(accounts)}，標記失敗", flush=True)
+            mark_done(it["label"], "unknown_account", 0, it["account"])
+            pending.remove(it)
+
         # 1) 把待辦工作塞進閒置的帳號槽位
         for name in accounts:
             if slots[name] is not None:
@@ -544,7 +576,7 @@ def main() -> None:
                   f"帳號 {name} 開始 {item['label']}"
                   f"\n  {item['script']} {item['args']}\n{'='*70}",
                   flush=True)
-            ok, kid, work_dir = push(item, name)
+            ok, kid, work_dir = push(item, name, accounts[name]["username"])
             if ok:
                 push_fail_counts.pop(item["label"], None)
                 slots[name] = {"phase": "running", "item": item, "kid": kid,

--- a/kaggle_sync.py
+++ b/kaggle_sync.py
@@ -105,6 +105,16 @@ def build_payload(script: str, extra_files: list[str], work_dir: Path,
     寫同一批檔案，內容互相覆蓋。改成每次呼叫傳入不同路徑
     （kaggle_queue.py 用帳號名稱區分），彼此才不會互相干擾。
     """
+    # rmtree 不可復原。只允許刪除 kaggle_work/ 底下的路徑——`--work-dir`
+    # 直接來自 CLI 參數，中間沒有任何驗證，誤傳 `--work-dir .` 或
+    # `--work-dir ~` 會遞歸刪光那個目錄的全部內容且沒有確認提示
+    # （2026-08-26 CodeRabbit 回溯審查抓到）。
+    work_dir = work_dir.resolve()
+    allowed_root = (HERE / "kaggle_work").resolve()
+    if allowed_root != work_dir and allowed_root not in work_dir.parents:
+        raise ValueError(
+            f"拒絕使用 {work_dir} 當打包目錄：必須位於 {allowed_root} "
+            f"底下（這個目錄會被整個清空重建）")
     if work_dir.exists():
         shutil.rmtree(work_dir)
     work_dir.mkdir(parents=True)


### PR DESCRIPTION
## 背景

PR #140 是對 CodeRabbit 上線前（`.coderabbit.yaml` 加入之前）的 44 個 commit 做的回溯審查，不會合併。CodeRabbit 給了 20 個 actionable comments，我逐項對照**目前的 main**（不是審查當下的舊快照）驗證，這個 PR 修的 4 個是確認仍然成立的真問題：

1. **`kaggle_accounts.py`**：舊流程（只有 `access_token`、沒有 `kaggle.json`）取不到 username 時原本留空繼續，下游 `kaggle_sync.py` 會組出缺 owner 前綴的 dataset/kernel ID（`/m45-imf-xxx`），要到 Kaggle CLI 呼叫 `datasets create` 才失敗，且錯誤訊息看不出根因。改成當場擋下、給出可行動的錯誤訊息。
2. **`kaggle_queue.py push()`**：原本每次 push 都重新 `load_accounts()`，但 `main()` 已經載入過一次。docstring 明講「執行中可以追加新工作到佇列」，使用者也可能在執行中編輯 `kaggle_accounts.json`——半寫入狀態會讓這裡的 `json.loads()` 拋例外，而主迴圈沒有 try/except，會直接拖垮整支常駐執行器，所有槽位裡在跑的 kernel 沒人追蹤。改成 username 由呼叫端傳入，不重新解析。
3. **`kaggle_queue.py` 主迴圈**：佇列項目若指定了不存在的帳號名稱（例如該帳號的 token 還是佔位字串、被 `load_accounts()` 略過），會永遠塞不進任何槽位，`pending` 永遠不空，執行器每 60 秒空轉一次、不印任何診斷訊息、也不會結束。改成啟動時就驗證帳號名稱，無效項目標記失敗並移出佇列。
4. **`kaggle_queue.py pull()`**：下載前只 `mkdir(exist_ok=True)`，不清掉上一次重試殘留的舊檔案。Kaggle CLI 用輸出檔案原始檔名、沒有明確覆寫選項，`is_mount_race_failure()` 會掃描目錄下所有 `*.log`，殘留的舊檔案可能讓這次真正的腳本錯誤被誤判成掛載時序問題，造成多餘重試、浪費 quota。改成下載前先清空目錄。
5. **`kaggle_sync.py build_payload()`**：`--work-dir` 直接來自 CLI 參數，沒有任何驗證就對它 `rmtree`。誤傳 `--work-dir .` 或 `--work-dir ~` 會遞歸刪光該目錄全部內容，且沒有確認提示，刪除不可復原。改成限制只能刪除 `kaggle_work/` 底下的路徑。

## 沒有在這個 PR 處理的

- 等時線網格邊界吸附與 `--free-lowmass` 搭配 config A/B 時 `theta` 索引錯位——這兩個更動到核心擬合邏輯，另開 PR 分開處理。
- 文件一致性類的發現（`LIMITATIONS.md`／`PAPER_OUTLINE.md`／教學文件裡的科學結論、數字、表格需要同步更新）——需要對科學內容的判斷，已整理回報給使用者，不在這裡自動改寫。

## 驗證方式

`py_compile` 三個檔案確認語法正確；純邏輯修正沒有可離線跑的整合測試（需要真的 Kaggle 帳號與 kernel），已仔細比對修改前後行為對既有正常路徑（帳號齊全、佇列正常、下載一次成功）完全不變。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>