### PR TITLE
fix: --free-lowmass 搭配無 dav 的 config 時 theta 索引錯位（PR #140 回溯審查）

### DIFF
--- a/fit_real.py
+++ b/fit_real.py
@@ -439,6 +439,25 @@ def main():
         print(f"錯誤：--configs 有不存在的設定名稱 {unknown}"
               f"（可用：{', '.join(CONFIGS)}）", flush=True)
         sys.exit(1)
+    # --free-lowmass 只在有 dav（config C/D）的設定下安全（2026-08-26
+    # CodeRabbit 回溯審查抓到）：enable_lowmass_fit() 一律把 p_lowmass
+    # 疊加在「目前 bounds 的最後一維」，而 JointModel.synthesise() 是位置
+    # 式解讀 theta——len(theta) > 6 時 theta[6] 一律當成 dav。A/B 沒有 dav
+    # （extra 是 None，enable_dav_fit() 不會被呼叫），bounds 只有 6 維，
+    # 若這裡還呼叫 enable_lowmass_fit()，p_lowmass 會被塞進 bounds 的
+    # 索引 6，跑起來卻被 synthesise() 誤讀成 dav；低質量段冪次實際上
+    # 全程沒被觸碰、仍是固定值，但輸出欄位會被標成「自由 p_lowmass」
+    # 擬合出來的結果，安靜地產生錯的數字。目前程式碼還沒有追蹤到底
+    # 疊加的是哪個參數的機制，先直接拒絕這個組合，不要生出誤標的結果。
+    if args.free_lowmass:
+        no_dav = [k for k in requested if CONFIGS[k][2] is None]
+        if no_dav:
+            print(f"錯誤：--free-lowmass 目前只支援有 dav 的設定"
+                  f"（C／D），{no_dav} 沒有 dav，疊加 p_lowmass 會被"
+                  f"synthesise() 誤讀成 dav、產生誤標的結果。請從 "
+                  f"--configs 移除 {no_dav}，或不要帶 --free-lowmass。",
+                  flush=True)
+            sys.exit(1)
     for key in requested:
         desc, s, extra, allow = CONFIGS[key]
         print(f"{'='*74}\n{key}：{desc}\n{'='*74}", flush=True)


### PR DESCRIPTION
## 背景

同一批 PR #140 回溯審查的另一個確認為真的問題，跟 #145（kaggle 派工/上傳流程）分開一個 PR，因為這個動到核心擬合邏輯，方便單獨驗證。

## 問題

`JointModel.enable_lowmass_fit()`（`pipeline/joint_fit.py`）一律把 `p_lowmass` 疊加在目前 `bounds` 的最後一維，而 `synthesise()` 是**位置式**解讀 `theta`：`len(theta) > 6` 時 `theta[6]` 一律當成 `dav`。

`config A/B` 沒有 `dav`（`enable_dav_fit()` 不會被呼叫，`bounds` 只有 6 維）。如果這時還呼叫 `--free-lowmass` 對應的 `enable_lowmass_fit()`，`p_lowmass` 會被塞進 `bounds` 索引 6——但跑起來時被 `synthesise()` 誤讀成 `dav`。結果是：低質量段冪次全程沒被真的觸碰（仍是固定值），但輸出欄位卻標成「自由 `p_lowmass`」擬合出來的結果，安靜產生誤標的數字。

程式碼裡其實已經有一行舊註解提到「只在 config C/D（有 dav 的設定）下有意義」，說明開發時就知道這個限制，但沒有真的擋掉這個組合。

**影響範圍**：已核對 `queue.txt`／`results/RESULTS_LOG.md`，目前唯一用過 `--free-lowmass` 的排程 `p2_free_lowmass` 只搭配 `--configs C`，不受影響——這是預防性修正，**不需要作廢任何既有結果**。

## 修法

在 `fit_real.py` 主迴圈前加驗證：`--free-lowmass` 搭配沒有 `dav` 的 config（即 `CONFIGS[key][2] is None`，目前是 A/B）直接中止，給出可行動的錯誤訊息，不產生誤標結果。

`inject_lowmass.py` 一律先呼叫 `enable_dav_fit()` 才呼叫 `enable_lowmass_fit()`，不受影響，不需要跟著改。

## 驗證

實際跑過 `python fit_real.py --configs A --free-lowmass --n-syn 1000 --repeats 1 --tag _guardtest`：確認會在計算開始前（資料載入、preflight 之後，主擬合迴圈之前）就印出錯誤訊息並 exit(1)，`results/` 底下沒有留下任何部分結果檔案。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>