### PR TITLE
fix: .coderabbit.yaml 別把真正的模型輸入檔跟著 data/** 一起排除（PR #140 回溯審查）

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -26,7 +26,16 @@ reviews:
     # 結果檔案（.npz/.csv/.json）跟快取的等時線網格不是給人看 diff 的，
     # 審這些只會製造噪音，排除掉。
     - "!results/**"
+    # data/** 大部分是可重建的原始下載（Gaia 查詢結果、HR23 交叉比對），
+    # 排除掉。**但下面三類是 fit_real.py／cluster_imf_tier1.py 等生產
+    # 腳本直接讀取的執行期輸入**（成員表、誤差模型、選擇函數），不是
+    # 單純的結果 diff 或快取——修改這些檔案時 CodeRabbit 必須看得到，
+    # 才審得出模型契約有沒有被改掉（2026-08-26 CodeRabbit 回溯審查
+    # PR #140 抓到原本整個 data/** 排除掉會連這三類一起藏住）。
     - "!data/**"
+    - "data/*cmd_members.csv"
+    - "data/*errmodel.npz"
+    - "data/*selection.npz"
     - "!isochrones/**"
     - "!logs/**"
     - "!kaggle_work/**"


### PR DESCRIPTION
PR #140 回溯審查抓到：原本 `path_filters` 整個排除 `data/**`，會連 `fit_real.py`／`cluster_imf_tier1.py` 等生產腳本直接讀取的執行期輸入（`cmd_members.csv`、`errmodel.npz`、`selection.npz`，以及各星團 `cluster_*_` 前綴的對應版本）一起藏住。這些不是結果 diff 或可重建的原始下載，修改成員表、誤差模型、選擇函數這種會直接改變模型契約的檔案時，CodeRabbit 應該要看得到才審得出來。

`data/**` 底下其餘檔案（Gaia 原始查詢下載如 `m45_r5_g18_plx4.csv`、HR23 交叉比對）維持排除，繼續當噪音濾掉。

用 `yaml.safe_load` 確認語法正確。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>