### PR TITLE
[Claude] 修正 cloud_queue.py 讓 git.exe 崩潰時不再跳出應用程式錯誤對話框

### DIFF
--- a/cloud_queue.py
+++ b/cloud_queue.py
@@ -53,6 +53,7 @@ worker 名稱可以是 `kaggle_accounts.json` 裡的帳號、也可以是
 """
 from __future__ import annotations
 
+import ctypes
 import os
 import subprocess
 import sys
@@ -67,6 +68,22 @@ import kaggle_queue
 import ssh_sync
 import ssh_workers
 from run_queue import _pid_alive
+
+if sys.platform == "win32":
+    # 2026-08-26 使用者實際遇到才發現：sync_queue_file() 每 60 秒對這個
+    # repo（跟另外幾個 worktree 共用同一份 .git 物件庫）打一次 git
+    # fetch/checkout，長時間跑下來偶爾會撞上 git.exe 自己初始化失敗
+    # （0xc0000142，STATUS_DLL_INIT_FAILED——這台機器是 ARM64，git.exe
+    # 是 x64 版，靠模擬層跑，加上這個 repo 同時有好幾個 worktree 在頻繁
+    # 打同一份物件庫，比一般狀況更容易踩到這類初始化競態）。這支程式是
+    # 沒人盯著的背景常駐服務，git.exe 崩潰時 Windows 照預設行為會跳出
+    # 「應用程式無法正常啟動...請按一下確定」的對話框，卡在那裡等人
+    # 手動點掉——但沒有人在看這台機器，對話框只會一直卡著。
+    # SetErrorMode(SEM_NOGPFAULTERRORBOX) 讓這個行程（跟它之後開的所有
+    # 子行程，包括 git.exe）崩潰時直接安靜結束、不跳對話框，崩潰本身
+    # 該有的處理（這裡是 subprocess.run() 檢查 returncode != 0 印警告、
+    # 沿用本機現有內容）完全不受影響，只是不再需要人去點「確定」。
+    ctypes.windll.kernel32.SetErrorMode(0x0002)  # SEM_NOGPFAULTERRORBOX
 
 HERE = Path(__file__).resolve().parent
 QUEUE = HERE / "cloud_queue.txt"
@@ -178,14 +195,15 @@ def sync_queue_file(branch: str = "main") -> None:
     try:
         r = subprocess.run(["git", "fetch", "origin", branch],
                            cwd=str(HERE), capture_output=True, text=True,
-                           timeout=30)
+                           timeout=30, creationflags=subprocess.CREATE_NO_WINDOW)
         if r.returncode != 0:
             print(f"  同步 {QUEUE.name} 失敗（git fetch：{r.stderr.strip()[:200]}），"
                  f"這輪沿用本機現有內容", flush=True)
             return
         r = subprocess.run(
             ["git", "checkout", f"origin/{branch}", "--", QUEUE.name],
-            cwd=str(HERE), capture_output=True, text=True, timeout=15)
+            cwd=str(HERE), capture_output=True, text=True, timeout=15,
+            creationflags=subprocess.CREATE_NO_WINDOW)
         if r.returncode != 0:
             print(f"  同步 {QUEUE.name} 失敗（git checkout："
                  f"{r.stderr.strip()[:200]}），這輪沿用本機現有內容",


### PR DESCRIPTION
## 動機
使用者回報：電腦不定時跳出「GIT.EXE - APPLICATION ERROR 應用程式無法
正常啟動(0xc0000142)，請按一下確定關閉應用程式」。

## 查證
- 這台機器是 Snapdragon X ARM64，git.exe 是 x64 版，靠模擬層跑。
- 這個 repo 同時有多個 worktree（`m45_cloud_workers_wt`／
  `m45_membership` 等）共用同一份 `.git` 物件庫，`cloud_queue.py` 的
  `sync_queue_file()` 每 60 秒對這份物件庫打一次 `git fetch` +
  `git checkout`，另一支主控板服務也會頻繁打同一份物件庫——比一般
  單一 worktree 的狀況更容易踩到 git.exe 自己的初始化競態
  （`0xc0000142` / `STATUS_DLL_INIT_FAILED`）。
- 實際觀察到 `logs/cloud_queue_runner.log` 裡出現「git fetch 失敗」
  但錯誤訊息完全空白的紀錄——符合 git.exe 崩潰（來不及寫任何
  stdout/stderr）而不是正常的網路層失敗。
- `cloud_queue.py` 是沒有人盯著的常駐背景服務，git.exe 崩潰時
  Windows 照預設行為跳出要人手動點「確定」的互動對話框，只會一直
  卡在那裡，不會自己消失。

## 修法
`SetErrorMode(SEM_NOGPFAULTERRORBOX)`：讓這個行程（跟它之後開的所有
子行程，包括 `git.exe`）崩潰時直接安靜結束、不跳互動對話框。
`sync_queue_file()` 本來就有檢查 `returncode`／逾時並優雅降級（印
警告、沿用本機現有內容），這支函式的行為完全不受影響，只是不再需要
人去點掉一個沒人看得到的對話框。

順手把 `sync_queue_file()` 的兩個 `git` 呼叫補上
`creationflags=CREATE_NO_WINDOW`——`ssh_workers.py` 的 `remote_run()`
前一天（2026-08-26）才修過同一類坑（沒這個旗標，`pyw`/背景常駐行程
底下每次呼叫都會瞬間跳一個主控台視窗），這裡是同一輪漏掉的另一個
呼叫點。

## 已知後續
- `status_dashboard/app.py` 那邊表現同樣症狀，已經在另一個 PR
  （status_dashboard 主控板）同步修好，並加了 60 秒冷卻時間降低跟
  這支程式的並發 git 壓力，兩邊算是同一輪修的。
- 過程中發現：實際在跑的 `m45_cloud_workers_wt` worktree 目前落後
  `origin/main` 不少（缺少 `gcp_vm_lifecycle.py` 那組「GCP VM 閒置
  自動關機省額度」的功能），且該 worktree 還有其他檔案處於未提交
  狀態（`ssh_sync.py`／`ssh_workers.py`／`restart_queue_on_boot.ps1`
  等）——這個落差不在這個 PR 處理範圍內，已經另外回報給使用者，
  由使用者決定何時整併。

## 驗證
- `ast.parse()` 語法檢查。
- 已經在實際跑的 `m45_cloud_workers_wt` worktree 上套用同樣的修改、
  重啟過真正的派工器行程，確認它正常啟動、完成一輪 `recover_running_slots()`
  復原、繼續往下跑（沒有卡住），過程沒有再看到崩潰對話框相關的異常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)