### PR TITLE
中控機改成雲端 Linux e2-micro（Always Free），不是任何人的筆電

### DIFF
--- a/docs/reference/CLOUD_WORKERS_IAP_SETUP.md
+++ b/docs/reference/CLOUD_WORKERS_IAP_SETUP.md
@@ -1,32 +1,42 @@
 # 多帳號 GCP 資源池：IAP tunnel + OS Login 設定
 
-2026-08-26 新增。解決兩個問題：(1) 傳統直連（開防火牆放行某個來源
-IP）在中控機換網路時就整個失效——2026-08-25 因為這樣斷線卡了好幾個
-小時，來源 IP 屬於學校的政府網段，之後也不會固定；(2) 三人各自有
-自己的 GCP 免費試用帳號、各自的 VM，希望互相共用成一個資源池，但
-不想把私鑰檔案分給彼此、也不想常駐開機把 $300／90 天的額度燒光。
+2026-08-26 新增，同日再訂正（見下方「中控機是雲端 VM，不是任何人的
+筆電」）。解決三個問題：(1) 傳統直連（開防火牆放行某個來源 IP）在
+中控機換網路時就整個失效——2026-08-25 因為這樣斷線卡了好幾個小時，
+來源 IP 屬於學校的政府網段，之後也不會固定；(2) 三人各自有自己的
+GCP 免費試用帳號、各自的 VM，希望互相共用成一個資源池，但不想把
+私鑰檔案分給彼此、也不想常駐開機把 $300／90 天的額度燒光；(3) 沒有
+人有條件讓自己的筆電 24 小時常開常連網——集中派工需要**某台機器**
+一直開著，這台機器不能是任何一個人的筆電。
 
-**架構沒有變**：仍然是[集中派工](../../cloud_queue.py)——只有一台
-中控機（目前是操作 `cloud_queue.py` 的這台）真正握有連線憑證跟
-派工邏輯，隊員完全不用碰任何憑證，一樣是對 `cloud_queue.txt` 開 PR
-加工作。這份文件多出來的東西是：中控機怎麼透過 IAP 安全連進**隊友
-自己專案裡的 VM**、以及怎麼自動開關機。傳統直連的既有 worker（例如
-Oracle，沒有 IAP）不受影響，繼續看 [CLOUD_WORKERS.md](CLOUD_WORKERS.md)。
+**中控機是雲端 VM，不是任何人的筆電**：`cloud_queue.py`／
+`iap_tunnel_manager.py` 這兩支常駐程式，跑在 GCP **Always Free**
+方案送的一台 `e2-micro`（永久免費，不是 90 天試用額度，見「給中控機
+操作者做一次」第 0 步）上，用**服務帳戶**（service account）而不是
+某個人的 Google 帳號登入——這台 VM 24/7 開著完全不用錢，也不依賴
+任何人記得開電腦。**架構其餘部分沒有變**：仍然是
+[集中派工](../../cloud_queue.py)——只有這一台協調 VM 真正握有連線
+憑證跟派工邏輯，隊員完全不用碰任何憑證，一樣是對 `cloud_queue.txt`
+開 PR 加工作。傳統直連的既有 worker（例如 Oracle，沒有 IAP）不受
+影響，繼續看 [CLOUD_WORKERS.md](CLOUD_WORKERS.md)。
 
 ## 為什麼是這個設計，不是別的
 
 - **不開 22 埠給任何來源 IP**——IAP tunnel 只放行 Google 的 IAP 固定
-  網段（`35.235.240.0/20`），連線本身靠中控機操作者自己的 Google
-  帳號登入驗證，不管換到哪個網路都連得上，也沒有「IP 白名單過期」
-  這種故障模式。
-- **不共用私鑰檔案**——OS Login 讓 SSH 驗證直接綁 Google 帳號身分，
-  金鑰由 `gcloud` 自動產生／管理，不需要把 `.pem` 之類的私鑰檔案
-  傳給操作中控機的人。誰能連、能連多久，直接在各自 GCP 專案的 IAM
-  頁面管控、隨時可以個別撤權。
-- **VM 開關權限留在中控機操作者手上，不留在每個人自己手上**——
-  因為維持「集中派工」架構，中控機需要能開/關**隊友的** VM 才能
+  網段（`35.235.240.0/20`），連線本身靠協調 VM 的服務帳戶身分驗證，
+  不管協調 VM 部署在哪個網路都連得上，也沒有「IP 白名單過期」這種
+  故障模式。
+- **不共用私鑰檔案**——OS Login 讓 SSH 驗證直接綁 Google 身分（這裡
+  是服務帳戶身分），金鑰由 `gcloud` 自動產生／管理，不需要把
+  `.pem` 之類的私鑰檔案傳來傳去。誰能連、能連多久，直接在各自 GCP
+  專案的 IAM 頁面管控、隨時可以個別撤權。
+- **中控機不是任何人的筆電**——用免費的 `e2-micro` 常駐雲端，不
+  依賴任何一個人的電腦開著、連著網路，是真正的 24/7，不是「盡力
+  而為」。
+- **VM 開關權限留在協調 VM 的服務帳戶身上，不留在每個人自己手上**——
+  因為維持「集中派工」架構，協調 VM 需要能開/關**隊友的** VM 才能
   自動省額度，所以隊友要把 `compute.instanceAdmin.v1`（建議用 IAM
-  條件限縮到單一 VM）授權給中控機操作者的帳號，不是反過來。這是
+  條件限縮到單一 VM）授權給協調 VM 的服務帳戶，不是反過來。這是
   比純 SSH 存取更大的信任範圍，隊友要知道這件事再照做。
 
 ## 給每個 VM 擁有者做一次（在自己的 GCP 專案）
@@ -61,31 +71,36 @@ gcloud compute project-info add-metadata --metadata enable-oslogin=TRUE
 （也可以只在單一 VM 的 metadata 加這個鍵，效果一樣，差別只是要不要
 影響專案裡其他 VM。）
 
-### 3. 把中控機操作者的 Google 帳號加進 IAM
+### 3. 把協調 VM 的服務帳戶加進 IAM
 
-`OPERATOR_EMAIL` 換成中控機操作者的 Google 帳號：
+**這裡開始要區分兩個不同的「服務帳戶」，不要搞混**：`COORDINATOR_SA`
+是協調 VM 附加的服務帳戶（**連線發起方**，見「給協調 VM 操作者做
+一次」第 0 步，格式類似
+`coordinator@COORDINATOR_PROJECT_ID.iam.gserviceaccount.com`）；
+下面第三段提到的「這台 worker VM 掛的 service account」是**另一個、
+完全不同的**服務帳戶（**連線目標的身分**，新建 VM 通常預設掛
+「Compute Engine default service account」）。兩個服務帳戶通常屬於
+不同專案，名字容易撞在一起看混，先弄清楚「誰在連、連去哪裡」再往下做。
+
+`COORDINATOR_SA` 換成協調 VM 那個服務帳戶的完整 email：
 
 ```bash
-# 讓中控機操作者能建立 IAP tunnel
+# 讓協調 VM 能建立 IAP tunnel
 gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
-  --member="user:OPERATOR_EMAIL" \
+  --member="serviceAccount:COORDINATOR_SA" \
   --role="roles/iap.tunnelResourceAccessor"
 
-# 讓中控機操作者能用自己的 Google 身分 SSH 登入（OS Login）
+# 讓協調 VM 能用它自己的服務帳戶身分 SSH 登入（OS Login）
 gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
-  --member="user:OPERATOR_EMAIL" \
+  --member="serviceAccount:COORDINATOR_SA" \
   --role="roles/compute.osLogin"
 ```
 
-**中控機操作者的 Google 帳號如果跟這個 VM 專案不同組織**（例如你們
-三人各自用自己的個人 Gmail 申請試用，不是同一個 Google Workspace
-組織——這是這個專案目前的實際情況）：一般情況下**不需要**額外設定，
-個人（非組織）專案本來就沒有「組織層級」這道關卡。只有當 VM 所在專案
-被歸在某個限制外部身分的 Google Workspace／Cloud Identity 組織底下
-時，才需要**那個組織的管理員**額外在組織層級授予中控機操作者
-`roles/compute.osLoginExternalUser`——不確定自己的專案算不算這種
-情況，直接照上面兩行 IAM 指令做，如果之後連線卡在身分驗證這一步，
-回頭查這一條。
+**跨專案的服務帳戶授權是很常見的 GCP 用法**（例如授權另一個專案的
+服務帳戶讀寫這個專案裡的 bucket），一般不需要額外的組織層級設定；
+如果 VM 所在專案被歸在某個限制外部身分的 Google Workspace／Cloud
+Identity 組織底下、上面兩行卡在權限錯誤，才需要那個組織的管理員
+另外處理，這種情況比較少見，遇到再查不遲。
 
 **開/關這台 VM 的權限，建議用自訂角色（custom role）縮到最小，不要
 整包 `compute.instanceAdmin.v1`**：`instanceAdmin.v1` 就算加了
@@ -105,7 +120,7 @@ gcloud iam roles create gcpIapWorkerLifecycle --project=YOUR_PROJECT_ID \
 
 # 用這個自訂角色 + IAM 條件把授權範圍限縮到單一 VM。
 gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
-  --member="user:OPERATOR_EMAIL" \
+  --member="serviceAccount:COORDINATOR_SA" \
   --role="projects/YOUR_PROJECT_ID/roles/gcpIapWorkerLifecycle" \
   --condition="expression=resource.name=='projects/YOUR_PROJECT_ID/zones/YOUR_ZONE/instances/YOUR_INSTANCE',title=limit-to-worker-vm"
 ```
@@ -116,60 +131,89 @@ gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
 
 ```bash
 gcloud projects add-iam-policy-binding YOUR_PROJECT_ID \
-  --member="user:OPERATOR_EMAIL" \
+  --member="serviceAccount:COORDINATOR_SA" \
   --role="roles/compute.instanceAdmin.v1" \
   --condition="expression=resource.name=='projects/YOUR_PROJECT_ID/zones/YOUR_ZONE/instances/YOUR_INSTANCE',title=limit-to-worker-vm"
 ```
 
-**VM 如果掛了 attached service account 要多加一條**：OS Login 對「VM 掛了 service
-account」的情況另外要求登入者在那個 service account 上有
-`roles/iam.serviceAccountUser`，理由是 SSH 進去等於能以那個 service
-account 的身分行動，GCP 每次連線都會檢查這個權限。先用主控台「VM 執行
-個體詳細資料」或 `gcloud compute instances describe VM_NAME
---format='value(serviceAccounts[0].email)'` 查有沒有掛 service
-account，有的話：
+**這台 worker VM 如果掛了 attached service account 要多加一條**——
+注意這裡指的是 worker VM 自己掛的那個服務帳戶（跟上面的
+`COORDINATOR_SA` 是兩回事，見本節開頭的說明）：OS Login 對「VM 掛了
+service account」的情況另外要求登入者（這裡是 `COORDINATOR_SA`）在
+那個 worker VM 自己的 service account 上有 `roles/iam.serviceAccountUser`，
+理由是 SSH 進去等於能以那個 service account 的身分行動，GCP 每次
+連線都會檢查這個權限。先用主控台「VM 執行個體詳細資料」或
+`gcloud compute instances describe VM_NAME
+--format='value(serviceAccounts[0].email)'` 查這台 worker VM 有沒有
+掛 service account，有的話：
 
 ```bash
-gcloud iam service-accounts add-iam-policy-binding SERVICE_ACCOUNT_EMAIL \
-  --member="user:OPERATOR_EMAIL" \
+gcloud iam service-accounts add-iam-policy-binding WORKER_VM_SERVICE_ACCOUNT_EMAIL \
+  --member="serviceAccount:COORDINATOR_SA" \
   --role="roles/iam.serviceAccountUser"
 ```
 
 新建的 VM 預設會掛「Compute Engine default service account」，多半
 會踩到這一條，不要跳過。
 
-### 4. 把連線資訊交給中控機操作者
+### 4. 把連線資訊交給協調 VM 的操作者
 
-告訴操作中控機的人這四項：`gcp_project`（你的專案 ID）、`gcp_zone`
+告訴操作協調 VM 的人這四項：`gcp_project`（你的專案 ID）、`gcp_zone`
 （VM 所在區域，例如 `asia-east1-c`）、`gcp_instance`（VM 的執行個體
 名稱）、以及你分配到的 `port`（建議照 gcp1=2201、gcp2=2202 這樣依序
-排，避免跟其他隊友的 tunnel 撞號——`ssh_workers.json` 是本機檔案，
-不進版控，這四項不是機密，用任何管道傳都可以）。
+排，避免跟其他隊友的 tunnel 撞號——`ssh_workers.json` 是協調 VM 上的
+本機檔案，不進版控，這四項不是機密，用任何管道傳都可以）。
 
-## 給中控機操作者做一次
+## 給協調 VM 操作者做一次
 
-**下面所有指令都用 Git Bash 或 WSL 執行，不要用 PowerShell**：這份
-文件的多行指令用行尾反斜線 `\` 換行接續，是 bash 的語法，PowerShell
-不認得這個換行符號——貼進 PowerShell 會被拆成一行主指令加好幾行各自
-獨立、缺參數的錯誤指令，不會照文件的意思執行。這台機器已經裝
-Git（`ssh`/`scp`/`git` 指令本身也是靠它），Git Bash 通常已經隨附
-裝好，開始功能表找「Git Bash」即可。
+**這裡整個流程都在 Linux 上做**：本機（你的筆電）不再需要跑
+`cloud_queue.py`／`iap_tunnel_manager.py`，只需要一開始建立協調 VM
+時連進去做初始設定，之後平常不用管它。下面的指令直接在協調 VM 的
+SSH 終端機（Debian／Ubuntu 的 bash，不是 Windows）裡執行。
 
-### 1. 裝 gcloud CLI
+### 0. 建立協調 VM（一次性）
 
-Windows：到 https://cloud.google.com/sdk/docs/install 下載安裝程式
-（若這台機器是 ARM64／Snapdragon X，優先找有沒有 ARM64 原生版，沒有
-就裝 x64 版走模擬——`gcloud` 本身是輕量的 Python/殼層包裝，不是算力
-密集工作，模擬開銷可忽略，不像 numpy/scipy 那種數值運算差幾十倍）。
-裝完：
+在你選定要 host 協調 VM 的那個 GCP 專案（可以是你們三人中任何一個
+人的專案，跟哪些專案是「worker」無關）：
+
+1. **先建服務帳戶**：主控台「IAM 與管理 → 服務帳戶 → 建立服務帳戶」，
+   取個名字（例如 `coordinator`），不用另外指定角色（要授權的角色
+   都是在**其他** worker 專案裡授權給它，見上面「給每個 VM 擁有者
+   做一次」第 3 步）。建好後記下它的完整 email，格式類似
+   `coordinator@YOUR_PROJECT_ID.iam.gserviceaccount.com`——這個
+   email 就是上面 `COORDINATOR_SA` 要填的值。
+2. **建 VM**：「Compute Engine → VM 執行個體 → 建立執行個體」：
+   - 機型：`e2-micro`（Always Free 只有這個機型免費）
+   - 區域：`us-west1`、`us-central1`、`us-east1` 三選一（**只有這
+     三區的 e2-micro 是永久免費，選別區會變成計費**，見上面「為
+     什麼是這個設計」段落）
+   - 開機磁碟：Debian 或 Ubuntu 皆可，用預設的 30GB（含在免費額度
+     內，不要調大，超過 30GB 會開始計費）
+   - 「身分與 API 存取權」：服務帳戶選第 1 步建的那個，存取範圍選
+     「允許完整存取所有 Cloud API」（最省事，這台機器不對外提供
+     服務，範圍寬鬆一點不是安全疑慮的重點——真正的存取邊界是
+     worker 專案那邊的 IAM 授權，不是這裡的 API 範圍）
+   - 防火牆：這台不需要對外提供服務，「允許 HTTP/HTTPS 流量」不用勾
+
+建好後用主控台的「SSH」按鈕（瀏覽器內建終端機）連進去，之後步驟都在
+這個終端機裡做。
+
+### 1. 裝 git、python3、gcloud CLI
+
+Debian／Ubuntu 通常已經預裝 `git`／`python3`；`gcloud` 需要另外裝：
 
 ```bash
+sudo apt update && sudo apt install -y git python3
+curl https://sdk.cloud.google.com | bash
+exec -l $SHELL
 gcloud init
-gcloud auth login
 ```
 
-用**中控機操作者自己的** Google 帳號登入（每個 VM 擁有者第 3 步加的
-就是這個帳號）。
+`gcloud init` 這一步**不用、也不能**用瀏覽器登入人類帳號——這台 VM
+沒有瀏覽器，且我們就是要用附加的服務帳戶身分，不是人類帳號。看到
+選擇帳戶的提示時，選已經自動偵測到的服務帳戶（通常會標示
+「Compute Engine default service account」或你在第 0 步建的那個
+名字），選它、不要另外走 OAuth 登入流程。
 
 ### 2. 建立並註冊一把 SSH 金鑰（**要先做這步再查使用者名稱**，
 見下一步的說明）
@@ -177,28 +221,25 @@ gcloud auth login
 **這裡走的是一般 `ssh`／`scp` 指令連到 tunnel 開的 `localhost:<port>`，
 不是 `gcloud compute ssh`**——後者會自動幫你產生、註冊、管理金鑰，
 前者不會，OS Login 開了、IAM 也授權了，沒有這一步照樣會在
-`ssh_sync.py push` 卡 `Permission denied (publickey)`。中控機操作者
-自己建一把專用金鑰：
+`ssh_sync.py push` 卡 `Permission denied (publickey)`。用協調 VM
+自己的服務帳戶身分建一把專用金鑰：
 
 ```bash
-ssh-keygen -t ed25519 -f ~/.ssh/gcp_iap_operator -C "gcp-iap-operator" -N ""
+ssh-keygen -t ed25519 -f ~/.ssh/gcp_iap_operator -C "gcp-iap-coordinator" -N ""
 ```
 
-**這把金鑰預設沒有 passphrase**：`ssh_workers.py` 的 `_SSH_OPTS` 開了
+**這把金鑰沒有 passphrase**：`ssh_workers.py` 的 `_SSH_OPTS` 開了
 `BatchMode=yes`（不彈互動式 prompt），這是為了讓 `cloud_queue.py`
-常駐無人值守運作，代價是沒辦法直接換成有 passphrase 的金鑰（除非
-另外接 SSH agent，這裡先不做，增加的複雜度不小）。這把私鑰檔案外洩，
-等於同時失去**所有已註冊 worker** 的 SSH 存取（仍然需要搭配 IAP
-tunnel／中控機操作者的 Google 身分才能實際連線，不是外洩就直接能連，
-但風險面確實比分開各自一把金鑰大）。想要更高安全性、範圍願意分開
-管理，可以改成**每個 worker 各自一把金鑰**（重複這一步、檔名各自取
-不同名字，下面註冊步驟各自對應各自的 `.pub`）；覺得目前共用一把可以
-接受，至少把私鑰檔案的存取權限鎖到只有中控機操作者自己的作業系統
-帳號能讀（Windows 用檔案總管對私鑰檔右鍵「內容→安全性」拿掉其他
-使用者的讀取權限）。
+常駐無人值守運作，代價是沒辦法直接換成有 passphrase 的金鑰。這台
+協調 VM 本身就是服務帳戶專用、不是人類日常登入的機器，私鑰檔案的
+存取權限預設就只有這個 VM 上的使用者能讀（Linux 的 `ssh-keygen`
+預設會把私鑰檔案權限設成 `600`，只有擁有者能讀），不需要額外設定；
+真正的風險邊界是「誰能 SSH 進這台協調 VM 本身」，這由這台 VM 所在
+專案自己的 IAM／OS Login 設定把關，跟人類操作者用筆電時是同一件事，
+不因為換成服務帳戶而變得更鬆。
 
-**OS Login 的金鑰是綁在你的 Google 帳號的全域 profile，不是個別
-專案各自一份清單**：`gcloud compute os-login ssh-keys add` 的
+**OS Login 的金鑰是綁在這個服務帳戶的全域 profile，不是個別專案
+各自一份清單**：`gcloud compute os-login ssh-keys add` 的
 `--project` 只是給這次 API 呼叫用哪個專案的身分驗證脈絡，寫入的
 目的地是同一份全域金鑰清單，不是那個專案專屬的副本。這件事有兩個
 實際影響：(1) 下面這行**理論上第一次對任何一個專案跑過一次就夠**，
@@ -208,11 +249,11 @@ gcloud 版本的行為差異），保險起見文件仍建議對每個要加入�
 不會有壞處。(2) **撤銷／移除這把金鑰是全域生效**，`ssh-keys remove`
 會讓這把 key 同時在**所有**用到它的專案失效，不是「只撤某個
 worker、其他 worker 不受影響」——如果之後只想讓某一台 VM 不能再被
-連，正確做法是去那個 VM 專案的 IAM 拿掉中控機操作者的角色（見上面
-「把中控機操作者的 Google 帳號加進 IAM」），不是靠移除金鑰，移除
+連，正確做法是去那個 VM 專案的 IAM 拿掉 `COORDINATOR_SA` 的角色
+（見上面「把協調 VM 的服務帳戶加進 IAM」），不是靠移除金鑰，移除
 金鑰是「這把金鑰完全作廢」的核選項。
 
-對要加入資源池的 VM 擁有者專案，把公鑰註冊進中控機操作者自己的
+對要加入資源池的 VM 擁有者專案，把公鑰註冊進這個服務帳戶自己的
 OS Login profile（要先 `gcloud config set project YOUR_PROJECT_ID`
 切到那個專案）：
 
@@ -235,49 +276,111 @@ gcloud compute os-login describe-profile --format='value(posixAccounts[0].userna
 
 第一次跑可能要先對目標專案跑 `gcloud config set project YOUR_PROJECT_ID`
 才查得到那個專案底下的帳號，不同專案可能查到不同格式的使用者名稱
-（例如 `你的帳號_gmail_com`），屬正常現象。查到空字串的話，先確認
-上一步的金鑰真的註冊成功（`gcloud compute os-login ssh-keys list`
-應該看得到），再重查一次。
+（服務帳戶的 OS Login 使用者名稱通常長得像 `sa_<一串數字>`），屬
+正常現象。查到空字串的話，先確認上一步的金鑰真的註冊成功
+（`gcloud compute os-login ssh-keys list` 應該看得到），再重查一次。
 
-### 4. 填 `ssh_workers.json`
+### 4. 抓這個 repo 的程式碼
+
+repo 是公開的，不需要任何 GitHub 憑證：
+
+```bash
+git clone https://github.com/helmet-png/m45-imf-analysis.git ~/m45_membership
+cd ~/m45_membership
+```
+
+`cloud_queue.py`／`iap_tunnel_manager.py`／`ssh_workers.py`／
+`ssh_sync.py`／`gcp_vm_lifecycle.py` 這些常駐派工用到的模組全部只用
+Python 標準庫，**不需要 `pip install` 任何套件**——`e2-micro` 只有
+1GB 記憶體，不裝 numpy/scipy 這類重量級套件正好，這台機器本來就
+不做任何實際運算，只負責發指令、查狀態。
+
+### 5. 填 `ssh_workers.json`
+
+還在 `~/m45_membership` 目錄下：
+
+```bash
+cp ssh_workers.json.example ssh_workers.json
+nano ssh_workers.json    # 或用你熟悉的編輯器
+```
 
 照 [ssh_workers.json.example](../../ssh_workers.json.example) 裡
 `gcp1`／`gcp2` 的範例格式，`host` 固定填 `"localhost"`、`key_path`
-填上一步建立的私鑰路徑（例如 `~/.ssh/gcp_iap_operator`，**不要留空**
-——留空會退回 ssh 預設身分，通常沒有註冊過 OS Login，會連不上）、
+填上面建立的私鑰路徑（`~/.ssh/gcp_iap_operator`，**不要留空**——
+留空會退回 ssh 預設身分，通常沒有註冊過 OS Login，會連不上）、
 `user` 填上一步查到的 OS Login 帳號、`port` 用 VM 擁有者分配的埠、
 `gcp_project`／`gcp_zone`／`gcp_instance` 填 VM 擁有者給的三項。
 
-### 5. 啟動 IAP tunnel 常駐管理器
+### 6. 設定成 systemd 服務，開機常駐、掛了自動重啟
+
+**不用移植 Windows 那套鎖檔案＋工作排程器的 watchdog 邏輯**——
+systemd 本身就是行程監督器，`Restart=always` 已經涵蓋「掛了自動
+重啟」，比另外寫一支輪詢腳本簡單、可靠：
 
 ```bash
-python iap_tunnel_manager.py
+sudo tee /etc/systemd/system/cloud-queue.service > /dev/null <<'EOF'
+[Unit]
+Description=M45 IMF cloud_queue.py dispatcher
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/YOUR_LINUX_USER/m45_membership
+ExecStart=/usr/bin/python3 -u cloud_queue.py
+Restart=always
+RestartSec=15
+User=YOUR_LINUX_USER
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo tee /etc/systemd/system/iap-tunnel-manager.service > /dev/null <<'EOF'
+[Unit]
+Description=M45 IMF IAP tunnel manager
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/YOUR_LINUX_USER/m45_membership
+ExecStart=/usr/bin/python3 -u iap_tunnel_manager.py
+Restart=always
+RestartSec=15
+User=YOUR_LINUX_USER
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+sudo systemctl daemon-reload
+sudo systemctl enable --now cloud-queue.service
+sudo systemctl enable --now iap-tunnel-manager.service
 ```
 
-正常應該會看到「開啟 gcp1 的 IAP tunnel」之類的訊息。這支程式要
-**常駐**——正常情況下不用手動啟動，Windows 排程會在登入時自動啟動並
-在掛掉時自動重啟（見 `restart_queue_on_boot.ps1`），跟 `cloud_queue.py`
-共用同一套機制。
+`YOUR_LINUX_USER` 換成你 SSH 進來時的使用者名稱（跑 `whoami` 查）、
+`/home/YOUR_LINUX_USER/m45_membership` 換成第 4 步 `git clone` 的
+實際路徑（如果照上面指令用 `~` 展開通常就是這個路徑）。
 
-### 6. 確認能連上
+### 7. 確認能連上
 
 ```bash
-python ssh_workers.py
+systemctl status cloud-queue.service iap-tunnel-manager.service
+journalctl -u cloud-queue.service -f
 ```
 
-會列出所有登記的 worker；再跑一次 `python ssh_sync.py push --worker gcp2`
-（換成剛加的 worker 名稱）確認能正常 `git clone`／`git pull`。第一次
-連線如果 VM 剛好是關機狀態，`push` 會自動觸發開機（見
-[gcp_vm_lifecycle.py](../../gcp_vm_lifecycle.py)），但這一次呼叫本身
-會回報失敗（`push` 這支獨立指令跟 `cloud_queue.py` 不一樣，**不會
-自己重試**，開機＋IAP tunnel 重新連線的等待時間需要手動處理）：
+`systemctl status` 應該顯示 `active (running)`；`journalctl -f`
+即時看 log，正常應該會看到「雲端佇列執行器啟動」之類的訊息，過一輪
+（60 秒）看到嘗試對已登記的 worker 派工／查狀態。第一次連線如果
+worker VM 剛好是關機狀態，`push()` 會自動觸發開機（見
+[gcp_vm_lifecycle.py](../../gcp_vm_lifecycle.py)），這一輪失敗、
+下一輪（60 秒後）自然接上，是正常現象，不代表設定錯誤。
 
-- **手動跑 `ssh_sync.py push` 這個指令本身**：看到失敗，等個
-  30–60 秒（VM 開機＋tunnel 重連的時間）**自己再手動跑一次**同一行
-  指令，不會自動重來。
-- **`cloud_queue.py` 常駐執行中**：它的主迴圈本來就會每輪（預設 60
-  秒）重新呼叫 `push()`，這種情況下第一次失敗不用管，等下一輪自然
-  會接上。
+想手動測試單一 worker（不透過常駐服務），可以先
+`sudo systemctl stop cloud-queue.service` 暫停常駐派工，再手動跑
+`python3 ssh_sync.py push --worker gcp2`，測完別忘了
+`sudo systemctl start cloud-queue.service` 恢復常駐。
 
 ## 自動開關機的行為
 
@@ -293,14 +396,16 @@ python ssh_workers.py
 
 ## 已知限制（誠實列出，不是隱藏起來）
 
-- **單點故障沒有解決**：資源池還是靠中控機那一台跑 `cloud_queue.py`，
-  那台機器沒開、沒連網，全隊都派不了工。這是延續現有「集中派工」架構
-  的既有取捨，不是這次改動新增的風險，但也沒有一併解決。
-- **中控機操作者的權限範圍變大**：第 3 步不管是用自訂角色還是退回
-  簡化版的 `compute.instanceAdmin.v1`，都是把「開/關某台 VM」的能力
-  授權給中控機操作者的帳號——如果漏了 `--condition` 限縮到單一執行
-  個體，簡化版會等同能開關該專案下的任何 VM，授權前務必先設定條件
-  限縮範圍。
+- **單點故障減輕了，但沒有完全解決**：資源池還是靠協調 VM 那一台跑
+  `cloud_queue.py`，比起某個人的筆電，雲端 e2-micro 24/7 開著、不
+  依賴任何人記得開機，可靠度好很多；但協調 VM 所在的**那個 GCP
+  專案**如果被停權、或那個帳戶的免費額度／Always Free 資格出問題，
+  全隊還是會一起派不了工——沒有做「協調 VM 本身也有備援」這件事。
+- **`COORDINATOR_SA` 的權限範圍變大**：第 3 步不管是用自訂角色還是
+  退回簡化版的 `compute.instanceAdmin.v1`，都是把「開/關某台 VM」的
+  能力授權給協調 VM 的服務帳戶——如果漏了 `--condition` 限縮到單一
+  執行個體，簡化版會等同能開關該專案下的任何 VM，授權前務必先設定
+  條件限縮範圍。
 - **免費試用不是只看 90 天，$300 額度先用完一樣會提前結束**：
   GCP 的 Free Trial 是「90 天
   或 $300 Welcome credit 用完，兩個條件哪個先到就先結束」，不是單純

--- a/run_queue.py
+++ b/run_queue.py
@@ -122,13 +122,47 @@ def _pid_alive(pid: int) -> bool | None:
     """回傳 True/False/None —— None 代表探測本身失敗（tasklist 逾時、
     找不到指令等），不能當成 False。
 
-    Windows 沒有 POSIX 的 os.kill(pid, 0) 探測語意 —— 傳 0 給 os.kill()
-    在 Windows 上會呼叫 TerminateProcess(handle, 0)，也就是真的把行程
-    殺掉，不是安全的存活探測。改用 tasklist 查詢，不會動到目標行程。
-    引數是 list 形式（不是 shell=True 的字串），pid 這裡永遠是
-    int(LOCK.read_text()) 解析出來的整數，不存在 shell injection 的
-    問題——自動掃描工具的 CWE-78 標記是這個模式的通用誤判，不是真的
-    有可控字串被組進 shell 命令。"""
+    **2026-08-26 加上 POSIX 分支**：`cloud_queue.py`／
+    `iap_tunnel_manager.py` 現在也會跑在 Linux 協調 VM 上（多帳號
+    資源池的中控機不再限定是某個人的 Windows 筆電，見
+    docs/reference/CLOUD_WORKERS_IAP_SETUP.md），這兩支程式的
+    `acquire_lock()` 都靠這支函式判斷鎖檔案裡的 PID 還活不活著——
+    原本這裡只有下面的 Windows `tasklist` 分支，在 Linux 上
+    `subprocess.run(["tasklist", ...])` 一定拋 `FileNotFoundError`
+    （被下面的 `except Exception` 接住），一律回傳 `None`，而
+    `acquire_lock()` 對 `None` 的處置是「保守當作還活著，直接
+    `sys.exit(1)` 退出」——後果是協調 VM 上只要發生過一次不乾淨的
+    結束（systemd 強制重啟、VM 被自動關機打斷），鎖檔案就永遠卡住，
+    之後每次 systemd 想重啟都會立刻退出、不會真的重新開始工作，
+    等於把「無人值守自動復原」這個換到雲端 VM 的整個目的完全抵銷，
+    而且不會有明顯的崩潰訊息，只會安靜地卡住。
+    Linux／macOS 用 POSIX 語意的 `os.kill(pid, 0)` 探測——送訊號 0
+    不會真的送出任何訊號，只做權限／存在性檢查，是不會誤殺目標行程的
+    安全做法（下面註解裡「傳 0 會殺掉行程」的陷阱是 Windows 特有的，
+    POSIX 平台上 signal 0 沒有這個問題，這是 Python 官方文件記載的
+    標準用法）。Windows 沒有這個 POSIX 語意，維持原本的 tasklist
+    查詢，邏輯完全不動。"""
+    if sys.platform != "win32":
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            # 行程存在，只是不是目前使用者能送訊號的對象（例如換了
+            # 使用者身分重啟過）——存在本身已經確定，當作活著。
+            return True
+        except OSError:
+            return None
+        else:
+            return True
+
+    # Windows 沒有 POSIX 的 os.kill(pid, 0) 探測語意 —— 傳 0 給 os.kill()
+    # 在 Windows 上會呼叫 TerminateProcess(handle, 0)，也就是真的把行程
+    # 殺掉，不是安全的存活探測。改用 tasklist 查詢，不會動到目標行程。
+    # 引數是 list 形式（不是 shell=True 的字串），pid 這裡永遠是
+    # int(LOCK.read_text()) 解析出來的整數，不存在 shell injection 的
+    # 問題——自動掃描工具的 CWE-78 標記是這個模式的通用誤判，不是真的
+    # 有可控字串被組進 shell 命令。
     # **2026-08-20 修**：原本用 text=True 讓 subprocess 自己決定編碼。
     # 這台是中文 Windows，`tasklist` 輸出 cp950（Big5）——平常剛好能解，
     # 但只要環境有 PYTHONUTF8=1（用 UTF-8 去解 Big5 位元組），解碼會在


### PR DESCRIPTION
## 動機
沒人有條件讓自己的筆電 24/7 開著連網。改用 GCP Always Free 送的一台 `e2-micro`（永久免費，跟 $300/90 天試用是兩回事）常駐跑 `cloud_queue.py`／`iap_tunnel_manager.py`，用附加的服務帳戶而不是人類 Google 帳號登入。

## 修的一個真實 bug
`run_queue.py` 的 `_pid_alive()` 只有 Windows `tasklist` 分支，Linux 上會失敗回傳 `None`，而 `acquire_lock()` 對 `None` 保守當作「還活著」直接退出——協調 VM 只要發生過一次不乾淨的結束，鎖檔案就永遠卡住，systemd 想自動重啟也沒用，等於把「換雲端就是為了無人值守」整個抵銷。加了 POSIX 分支（`os.kill(pid, 0)`），Windows 分支不動。

確認 `cloud_queue.py`／`ssh_sync.py`／`ssh_workers.py`／`gcp_vm_lifecycle.py`／`iap_tunnel_manager.py` 都已經是 PR #133 那輪修好的可攜版本，不需要再改。

## 文件重寫
`docs/reference/CLOUD_WORKERS_IAP_SETUP.md`「給中控機操作者做一次」整節改寫成 Linux + 服務帳戶 + systemd：新增第 0 步（建 e2-micro，只有 `us-west1`/`us-central1`/`us-east1` 免費）、認證改用附加服務帳戶、repo 公開所以 HTTPS clone 免憑證、依賴全標準庫不用 pip install、`systemd`（`Restart=always`）取代 Windows 工作排程器。IAM 段落把 `user:OPERATOR_EMAIL` 全部換成 `serviceAccount:COORDINATOR_SA`，並明確區分「協調 VM 的服務帳戶」跟「worker VM 自己掛的 service account」兩個不同角色。

## 驗證
`py_compile` 全過；`ruff` 無新增告警；`_pid_alive()` POSIX 分支用強制 `sys.platform` 在 Windows 機器上做過邏輯層面煙霧測試；文件 code fence 配對、標題編號連續、無殘留 `OPERATOR_EMAIL`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)