### PR TITLE
修好 cloud_queue.py 在 Linux 上啟動即崩潰：CREATE_NO_WINDOW 是 Windows 專屬

### DIFF
--- a/cloud_queue.py
+++ b/cloud_queue.py
@@ -195,7 +195,7 @@ def sync_queue_file(branch: str = "main") -> None:
     try:
         r = subprocess.run(["git", "fetch", "origin", branch],
                            cwd=str(HERE), capture_output=True, text=True,
-                           timeout=30, creationflags=subprocess.CREATE_NO_WINDOW)
+                           timeout=30, creationflags=ssh_workers.CREATE_NO_WINDOW)
         if r.returncode != 0:
             print(f"  同步 {QUEUE.name} 失敗（git fetch：{r.stderr.strip()[:200]}），"
                  f"這輪沿用本機現有內容", flush=True)
@@ -203,7 +203,7 @@ def sync_queue_file(branch: str = "main") -> None:
         r = subprocess.run(
             ["git", "checkout", f"origin/{branch}", "--", QUEUE.name],
             cwd=str(HERE), capture_output=True, text=True, timeout=15,
-            creationflags=subprocess.CREATE_NO_WINDOW)
+            creationflags=ssh_workers.CREATE_NO_WINDOW)
         if r.returncode != 0:
             print(f"  同步 {QUEUE.name} 失敗（git checkout："
                  f"{r.stderr.strip()[:200]}），這輪沿用本機現有內容",

--- a/run_queue.py
+++ b/run_queue.py
@@ -29,6 +29,18 @@ import time
 from datetime import datetime
 from pathlib import Path
 
+# subprocess.CREATE_NO_WINDOW 只存在於 Windows 版的 subprocess 模組。
+# **2026-08-29 實際造成事故才補上**：cloud_queue.py 匯入這支模組，而
+# 協調角色已經搬到 Linux VM 上跑——直接參照 subprocess.CREATE_NO_WINDOW
+# 會在 subprocess.run() 執行前就先拋 AttributeError，讓 cloud_queue.py
+# 每次啟動幾秒內就崩潰，systemd 不斷重啟（實測重試計數器累積到 5130
+# 次），服務看起來 active 但實際上完全沒在派工，gcp1 因此閒置超過 20
+# 小時、算完的結果沒人收，兩台 VM 都在計費卻都沒產出。
+# 用 getattr 給預設值 0，非 Windows 平台安全地變成無操作，跟沒傳這個
+# 參數效果相同。ssh_workers.py／gcp_vm_lifecycle.py 早就是這個寫法，
+# 這支跟 cloud_queue.py 當初漏掉了。
+_CREATE_NO_WINDOW = getattr(subprocess, "CREATE_NO_WINDOW", 0)
+
 HERE = Path(__file__).resolve().parent
 QUEUE = HERE / "queue.txt"
 DONE = HERE / "logs" / "queue_done.txt"
@@ -184,7 +196,7 @@ def _pid_alive(pid: int) -> bool | None:
         out = subprocess.run(
             ["tasklist", "/FI", f"PID eq {pid}", "/FO", "CSV", "/NH"],
             capture_output=True, timeout=5,
-            creationflags=subprocess.CREATE_NO_WINDOW)
+            creationflags=_CREATE_NO_WINDOW)
     except Exception:                                 # noqa: BLE001
         return None
     if out.returncode != 0 or out.stdout is None:
@@ -226,7 +238,7 @@ def _process_tree_cpu_ticks(root_pid: int) -> int | None:
              "Select-Object ProcessId,ParentProcessId,KernelModeTime,"
              "UserModeTime | ConvertTo-Csv -NoTypeInformation"],
             capture_output=True, timeout=30,
-            creationflags=subprocess.CREATE_NO_WINDOW)
+            creationflags=_CREATE_NO_WINDOW)
     except Exception:                                     # noqa: BLE001
         return None
     # 同 _pid_alive() 的理由（見那邊 2026-08-20 的說明）：自己解碼，
@@ -333,7 +345,7 @@ def _kill_process_tree(pid: int):
     try:
         subprocess.run(["taskkill", "/PID", str(pid), "/T", "/F"],
                        capture_output=True, timeout=15,
-                       creationflags=subprocess.CREATE_NO_WINDOW)
+                       creationflags=_CREATE_NO_WINDOW)
     except Exception:                                     # noqa: BLE001
         pass
 


### PR DESCRIPTION
雲端協調 VM（instance-20260827-035250，Debian）上的 cloud-queue.service 一直處於「啟動幾秒就崩潰、systemd 立刻重啟」的無限迴圈，重試計數器累積
到 5130 次。systemctl status 顯示 active (running)，很容易誤判成正常， 實際上服務從來沒有活過一輪迴圈。

    AttributeError: module 'subprocess' has no attribute 'CREATE_NO_WINDOW'
    File ".../cloud_queue.py", line 198, in sync_queue_file

subprocess.CREATE_NO_WINDOW 只存在於 Windows 版的 subprocess 模組。這兩行 是 2026-08-26 為了解決 Windows 上 git.exe 崩潰跳對話框而加的，當時協調角色 還在 Windows 筆電上跑，沒有考慮到同一份程式碼之後會搬到 Linux。

實際造成的損失：協調 VM 從 8/27 起就沒有真正派過工。gcp1 的 p6_lowmass_v3 在 8/28 19:54 就已經跑完（exit=0，results/profile_lowmass.npz 產出正常）， 但沒有任何程序去收結果、也沒有派下一項，gcp1 閒置超過 20 小時，兩台 VM
都在計費卻都沒有產出。

修法沿用專案裡既有的正確寫法（ssh_workers.py 第 45 行、gcp_vm_lifecycle.py 第 40 行都已經是這樣）：用 getattr 取值、非 Windows 平台安全地退化成 0，
效果等同沒傳這個參數。

- cloud_queue.py（2 處）：改用 ssh_workers.CREATE_NO_WINDOW，該模組本來就 已經匯入，且它定義這個常數的註解明講「ssh_sync.py 也重用這個常數，不要 各自定義一份」。
- run_queue.py（3 處）：cloud_queue.py 會 `from run_queue import ...`，所以 這支的同類問題一樣會讓 Linux 上的協調服務掛掉，一併修。新增模組層級的 _CREATE_NO_WINDOW 常數。

同一支檔案裡的 ctypes.windll 用法不受影響：cloud_queue.py 的那段有
`if sys.platform == "win32"` 保護，run_queue.py 的 keep_system_awake()／ release_system_awake() 則有 except (AttributeError, OSError) 接住，兩者在 Linux 上本來就會安全略過。

已驗證：py_compile 通過；確認 run_queue.py 剩下的兩處 CREATE_NO_WINDOW 字樣都在註解裡、不是程式碼。