### PR TITLE
支援 Python 3.10：tomllib 找不到時退回 tomli

### DIFF
--- a/pdmf_limepy_smoke.py
+++ b/pdmf_limepy_smoke.py
@@ -16,8 +16,12 @@ import json
 import math
 import sys
 import time
-import tomllib
 from pathlib import Path
+
+try:                                # Python < 3.11 沒有 tomllib，
+    import tomllib                  # 理由見 pipeline/config.py 同一段
+except ModuleNotFoundError:
+    import tomli as tomllib
 
 import numpy as np
 

--- a/pipeline/config.py
+++ b/pipeline/config.py
@@ -6,8 +6,26 @@
 """
 from __future__ import annotations
 
-import tomllib
 from pathlib import Path
+
+# tomllib 是 Python 3.11 才進標準庫的；3.10 以下要用 PyPI 上的 tomli
+# （同一批作者、同一套 API——tomllib 本來就是從 tomli 收編進標準庫的，
+# 所以 `import tomli as tomllib` 之後下游程式碼一行都不用改）。
+#
+# **2026-08-29 實際踩到才補上**：新接進來的運算節點是 Ubuntu 22.04，
+# 內建 Python 3.10.12，`import tomllib` 直接 ModuleNotFoundError，
+# 整條 pipeline 在載入設定檔這一步就死掉。原本的寫法等於隱性要求每台
+# worker 都是 3.11+，但這個限制既沒寫進文件、也沒有任何檢查會提早
+# 報錯——只有真的派工下去、跑到一半才會發現。
+#
+# 不改成「要求 worker 升級 Python」的理由：升級系統 Python 需要 root
+# 權限，而 worker 常常是別人提供的機器（這次就是學長的），不該為了
+# 我們的專案去動人家的系統環境；裝一個純 Python 的相容套件到使用者
+# 家目錄就能解決，代價小得多。
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_PATH = ROOT / "config.toml"

--- a/scripts/tools/preflight.py
+++ b/scripts/tools/preflight.py
@@ -207,7 +207,10 @@ def audit_common(model, grid, refines, *, script: str,
     模型實際生效的值有沒有精確等於這個刻意值——如果哪天覆寫那行被
     不小心刪掉、或值被改動，這裡還是抓得到。
     """
-    import tomllib
+    try:                                # Python < 3.11 沒有 tomllib，
+        import tomllib                  # 理由見 pipeline/config.py 同一段
+    except ModuleNotFoundError:
+        import tomli as tomllib
     from injection_recovery import COARSE
     fails, warns = [], []
     overrides = expected_overrides or {}


### PR DESCRIPTION
新接進來的運算節點（24 核，隊友提供）是 Ubuntu 22.04，內建 Python
3.10.12，沒有 tomllib——那是 3.11 才進標準庫的。實測 `import tomllib` 直接 ModuleNotFoundError，整條 pipeline 在載入 config.toml 這一步就死掉， 連匯入都過不了。

原本的寫法等於隱性要求每台 worker 都是 Python 3.11+，但這個限制既沒有
寫進文件、也沒有任何檢查會提早報錯——只有真的派工下去、跑到一半才會
發現，而那時候機時已經花掉了。

改成標準的相容寫法：先試 tomllib，ModuleNotFoundError 就退回 tomli。 兩者是同一批作者、同一套 API（tomllib 本來就是從 tomli 收編進標準庫
的），`import tomli as tomllib` 之後下游程式碼一行都不用改。

不改成「要求 worker 升級 Python」的理由：升級系統 Python 需要 root
權限，而 worker 常常是別人提供的機器（這次就是隊友的），不該為了我們
的專案去動人家的系統環境；裝一個純 Python 的相容套件到使用者家目錄就
能解決，代價小得多。

三個 import 點都改：pipeline/config.py（模組層級）、
scripts/tools/preflight.py（函式內）、pdmf_limepy_smoke.py（模組層級）。

已驗證：
- 三個檔案 py_compile 通過
- Windows/Python 3.13（本機）上 config.load() 仍正常，走的是原本的 tomllib 分支，行為不變
- Ubuntu 22.04/Python 3.10.12（新 worker）上實測 pipeline 全部模組、 measure_overconfidence、config.load() 都能正常匯入與執行