### PR TITLE
[Claude] 主控板索引補齊 stars_per_cluster 步驟 + CONTRIBUTING 檢查清單

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -503,6 +503,9 @@ token 去猜**，先看 `git log`／PR 紀錄能不能查到；真的看不出�
 - [ ] 若編輯 `LIMITATIONS.md`：新增／修改的條目照第五節的格式與分級
 - [ ] 若編輯 `WORK_BOARD.md`：任務名稱有標對應的 `LIMITATIONS.md` 條目
       （見五之一），且已回頭同步該條目括號裡的工作狀態
+- [ ] 若在 `WORK_BOARD.md` 新增任務、或新增/搬動了 pipeline 相關腳本：
+      已回頭在 `status_dashboard/stage_map.py` 加一筆對應的步驟（見第二節
+      「主控板」段落），不要讓主控板的索引跟實際工作脫節
 - [ ] 若某條 `LIMITATIONS.md` 因為這次工作而完全解決：已搬到
       `RESOLVED.md`，不是留在原處或直接刪掉
 - [ ] 若這次工作有新發現／推翻舊說法而編輯了 `LIMITATIONS.md` 或

--- a/status_dashboard/stage_map.py
+++ b/status_dashboard/stage_map.py
@@ -492,6 +492,15 @@ STAGES = [
                 "queue_labels": ["p6b_inject_lowmass_v2"],
             },
             {
+                "name": "D2 stars_per_cluster 敏感度掃描",
+                "scripts": [],
+                "note": ("可行性查證已完成、確認執行受阻：repo 缺 pyUPMASK/、"
+                        "缺 prepared/ 輸入，run_variant.py 也未暴露對應的參數"
+                        "旗標，需要有 pyUPMASK 環境的機器才能真的量出敏感度"
+                        "數字（2026-08-25，見 WORK_BOARD.md／"
+                        "WORK_BOARD_DONE.md）。"),
+            },
+            {
                 "name": "D2 membership_threshold 敏感度掃描",
                 "scripts": ["scripts/diagnostics/sensitivity_sweep.py"],
                 # 注意：WORK_BOARD.md 裡這個任務叫


### PR DESCRIPTION
## 做了什麼

1. **`status_dashboard/stage_map.py`**：交叉比對 `WORK_BOARD.md` 全部
   16 項在辦任務、`WORK_BOARD_DONE.md` 全部已結案項目，跟現有 24 個索引
   步驟逐一對照，找出唯一還沒補進索引的在辦任務——`stars_per_cluster_sensitivity`
   （D2 的另一個敏感度掃描目標）。已補上一個新步驟，標記可行性已查證受阻
   （缺 pyUPMASK 環境三項依賴），沒有可執行的腳本。

   過程中原本以為的另一個 bug（`mass_dependent_fbin` 步驟腳本路徑指錯）
   查證後發現已經在 2026-08-26 的另一次修改裡修好了，不需要再動。

2. **`CONTRIBUTING.md`**：第二節「結果檔案規範」段落已經有「新增
   `WORK_BOARD.md` 任務或新腳本時記得回 `stage_map.py` 加一筆」的文字
   說明，但第七節「開 PR 前快速檢查清單」沒有對應項目，實際開 PR 時容易
   被忽略而漏掉。補一條 checklist 項目，跟既有的 `RESULTS_LOG.md`／
   `LIMITATIONS.md` 檢查項目放在一起。

## 驗證

`py -c "import status_dashboard.stage_map"` 通過，步驟數從 24 增為 25。