### PR TITLE
[Claude] 修好 stage_map.py 失效路徑 + 加 CI 自動檢查防止再發生

### DIFF
--- a/.github/workflows/stage-map-path-check.yml
+++ b/.github/workflows/stage-map-path-check.yml
@@ -1,0 +1,30 @@
+name: Dashboard stage_map path check
+
+# status_dashboard/stage_map.py 是手動維護的「步驟→腳本」索引（見該檔頭
+# 說明），跟真正的腳本檔案之間沒有任何程式層級的關聯——搬檔案／改名
+# 的 PR 完全不會動到它，路徑對不上只會讓主控板悄悄顯示「本機找不到」，
+# 沒人會主動發現（2026-08-31 實際發生過，nbody/multicluster 那批腳本
+# 搬進子目錄後才注意到）。
+#
+# 不限定 paths 觸發條件：任何一次 PR 都跑，因為問題可能來自「動了
+# 腳本」也可能來自「動了 stage_map.py」，這支檢查很快（只讀檔案系統，
+# 不需要任何依賴），限縮觸發範圍省的時間不值得冒著漏檢的風險。
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Verify stage_map.py script paths exist
+        run: python3 scripts/tools/check_stage_map_paths.py

--- a/scripts/tools/check_stage_map_paths.py
+++ b/scripts/tools/check_stage_map_paths.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""驗證 `status_dashboard/stage_map.py` 裡列的每支 script 路徑，在 repo
+裡真的存在——2026-08-31 發現的問題：`scripts/tools/reorganize.py` 之類
+的搬檔案／改名 commit 完全不會動到 `stage_map.py`（兩者沒有程式層級的
+關聯，只是同一批人手動維護），檔案搬走後主控板會一直顯示「本機找不到」
+卻沒有人會主動發現，直到有人剛好點開那個步驟才踩到。
+
+這支腳本補上自動化的那一道檢查：CI 每次 PR 都跑一次，路徑對不上就讓
+建置失敗，逼搬檔案的人順手更新 `stage_map.py`（跟 `git mv` 忘記更新
+import 路徑是同一類坑，只是這裡沒有 import 錯誤可以提示，得自己檢查）。
+
+`external`（第三方套件，見 stage_map.py 檔頭說明）裡列的路徑本來就允許
+本機沒有，跳過不驗證。
+
+用法：
+    python3 scripts/tools/check_stage_map_paths.py
+在 repo 根目錄執行，找到任何找不到的路徑就印出來並以非 0 結束。
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+
+sys.path.insert(0, str(REPO_ROOT / "status_dashboard"))
+from stage_map import STAGES  # noqa: E402
+
+
+def main() -> int:
+    missing: list[tuple[str, str, str]] = []
+    for stage in STAGES:
+        for step in stage["steps"]:
+            external = step.get("external", {})
+            for script in step.get("scripts", []):
+                if script in external:
+                    continue
+                if not (REPO_ROOT / script).is_file():
+                    missing.append((stage["name"], step["name"], script))
+
+    if not missing:
+        print("stage_map.py 裡的腳本路徑全部存在，檢查通過。")
+        return 0
+
+    print("stage_map.py 裡有腳本路徑在本機找不到，可能是搬檔案／改名"
+          "後忘記同步更新（也可能是 external 漏標）：\n")
+    for stage_name, step_name, script in missing:
+        print(f"  [{stage_name} / {step_name}] {script}")
+    print(f"\n共 {len(missing)} 筆。請更新 status_dashboard/stage_map.py "
+          "對應的 scripts 路徑，或若是第三方套件就補上 external 標記。")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/status_dashboard/stage_map.py
+++ b/status_dashboard/stage_map.py
@@ -429,10 +429,10 @@ STAGES = [
             {
                 "name": "第5步 N-body 校準（PeTar / Converse & Stahler 2010）",
                 "scripts": [
-                    "nbody_pdmf_smoke.py",
-                    "nbody_pdmf_ensemble.py",
-                    "petar_pdmf_analysis.py",
-                    "petar_pdmf_ensemble.py",
+                    "scripts/nbody_petar/nbody_pdmf_smoke.py",
+                    "scripts/nbody_petar/nbody_pdmf_ensemble.py",
+                    "scripts/nbody_petar/petar_pdmf_analysis.py",
+                    "scripts/nbody_petar/petar_pdmf_ensemble.py",
                 ],
                 "queue_labels": ["nbody_prior_from_radial"],
                 "key_points": [
@@ -563,7 +563,7 @@ STAGES = [
                 "name": "praesepe_pr11_close_out（D8、A5）Praesepe 多星團驗證收尾",
                 "scripts": [
                     "scripts/multicluster/cluster_imf_tier1.py",
-                    "cluster_forward_validation.py",
+                    "scripts/multicluster/cluster_forward_validation.py",
                 ],
                 # PR #11 實際上已經合併（codex/ngc3532-praesepe-generalization，
                 # 見 WORK_BOARD_DONE.md 2026-08-20 那行），這個任務名稱本身
@@ -576,7 +576,7 @@ STAGES = [
                 "name": "comaber_tier1（A5、D8）Coma Berenices 多星團驗證",
                 "scripts": [
                     "scripts/multicluster/cluster_imf_tier1.py",
-                    "prepare_cluster_tier2.py",
+                    "scripts/multicluster/prepare_cluster_tier2.py",
                 ],
                 "queue_labels": ["comaber_tier1"],
             },


### PR DESCRIPTION
## 問題

PR #152 把 nbody/multicluster/petar 那批腳本搬進子目錄後，`status_dashboard/stage_map.py` 裡對應的 6 個路徑沒有跟著更新，因為這兩份檔案之間沒有任何程式層級的關聯——搬檔案的 PR 完全不會觸發任何提醒，主控板只會悄悄顯示「本機找不到」，沒人會主動發現。

## 修好的路徑

- `nbody_pdmf_smoke.py`／`nbody_pdmf_ensemble.py`／`petar_pdmf_analysis.py`／`petar_pdmf_ensemble.py` → `scripts/nbody_petar/`
- `cluster_forward_validation.py`／`prepare_cluster_tier2.py` → `scripts/multicluster/`

## 防止再發生

加了 `scripts/tools/check_stage_map_paths.py`（驗證 stage_map.py 裡每個非 external 的腳本路徑真的存在）+ `.github/workflows/stage-map-path-check.yml`（每個 PR 都跑，路徑對不上就讓 CI 失敗）。以後誰搬檔案忘記同步 `stage_map.py`，CI 會直接擋下來，不用等人剛好點開那個步驟才發現。