### PR TITLE
[Claude] 整合雲端/本機主控板：桌面捷徑改連協調 VM

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,16 +330,39 @@ diff 完全看不出真正改了什麼，審查等於白審。**這才是「PR �
 「王小明」），commit hash 填**跑這個結果當下** `git rev-parse HEAD`
 的值，讓任何人事後都能精確對回當時的程式碼版本，不必另外拉 git tag。
 
-**主控板（`status_dashboard/`，2026-08-24 新增）**：`py
-status_dashboard/app.py`（或雙擊桌面捷徑）開一個本機網頁，把「傳統法／
-前向模型／PDMF→IMF／穩健性診斷」四大類底下有哪些步驟、每個步驟對應
-哪些腳本、目前執行到哪，整理在同一頁——取代翻十幾份 `.md` 文件才能拼
-出全貌的做法。「階段 → 步驟 → 腳本」的對照表在
-`status_dashboard/stage_map.py`，是**手動維護**的索引（沒有機器可讀的
-來源能自動生成傳統法／PDMF→IMF／診斷類的分類結構）。**新增
+**主控板（`status_dashboard/`，2026-08-24 新增；2026-09-02 起搬到協調
+VM，見下段）**：把「傳統法／前向模型／PDMF→IMF／穩健性診斷」四大類
+底下有哪些步驟、每個步驟對應哪些腳本、目前執行到哪，整理在同一頁——
+取代翻十幾份 `.md` 文件才能拼出全貌的做法。「階段 → 步驟 → 腳本」的
+對照表在 `status_dashboard/stage_map.py`，是**手動維護**的索引（沒有
+機器可讀的來源能自動生成傳統法／PDMF→IMF／診斷類的分類結構）。**新增
 `WORK_BOARD.md` 任務或新腳本時，記得回來 `stage_map.py` 加一筆**，
 跟這裡「新結果要記進 `RESULTS_LOG.md`」是同一種「找不到自動生成辦法、
 只能手動維護索引」的協作規則。
+
+**只有一份、跑在協調 VM 上，不是每個人各自跑一份**（2026-09-02 決定）：
+主控板本身現在跟 `cloud_queue.py` 一樣常駐在協調 VM（見「三、雲端
+worker」段落跟 `docs/reference/CLOUD_WORKERS_IAP_SETUP.md`），所有人
+看到的是同一份即時派工狀態，不會有「我這份」「你那份」各自不同步的
+問題。要連上去：
+
+```bash
+gcloud compute start-iap-tunnel instance-20260827-035250 8866 \
+  --local-host-port=localhost:8866 --zone=us-central1-a \
+  --project=project-f6e2d0e1-cd17-4cfb-a9b
+```
+
+跑完在瀏覽器開 `http://localhost:8866/`。**Windows 使用者**：雙擊
+`status_dashboard/launch_dashboard.vbs`（或桌面捷徑）會自動處理上面
+這件事（開 tunnel、等連上、開瀏覽器），不用背指令。**macOS／Linux**：
+把上面那行存成自己的 shell script／alias，或直接照
+`status_dashboard/open_dashboard.py` 的邏輯（連得到就開瀏覽器，連不到
+就先開 tunnel）寫一支對應的本機啟動器。
+
+**改主控板程式碼**：`app.py` 每次有人整理頁面都會自動 `git pull`，PR
+合併進 `main` 之後下一次任何人重新整理頁面就自動套用新版，不用手動
+登入協調 VM。`cloud_queue.py` 沒有這套自動重啟，改了要手動 SSH 進去
+`git pull && sudo systemctl restart cloud-queue.service`。
 
 ---
 

--- a/status_dashboard/launch_dashboard.vbs
+++ b/status_dashboard/launch_dashboard.vbs
@@ -2,13 +2,10 @@ Set sh = CreateObject("WScript.Shell")
 Set fso = CreateObject("Scripting.FileSystemObject")
 dir_ = fso.GetParentFolderName(WScript.ScriptFullName)
 
-' Temporary override until the worktree is folded back into main;
-' see app.py header comment for the full explanation (kept out of
-' this file because non-ASCII text here breaks cscript/wscript on
-' a Chinese-codepage Windows system).
-Set env = sh.Environment("Process")
-env("CLOUD_QUEUE_ROOT") = "C:\Users\Alber\Claude\m45_cloud_workers_wt"
-
-sh.Run "pyw """ & dir_ & "\app.py""", 0, False
-WScript.Sleep 1500
-sh.Run "http://127.0.0.1:8866/", 1, False
+' 2026-09-02: main board now runs on the coordinator VM (see
+' docs/reference/CLOUD_WORKERS_IAP_SETUP.md), not locally. This just
+' opens an IAP tunnel (if not already open) and the browser; see
+' open_dashboard.py for the full explanation. Non-ASCII text kept out
+' of this file because it breaks cscript/wscript on a Chinese-codepage
+' Windows system.
+sh.Run "pyw """ & dir_ & "\open_dashboard.py""", 0, False

--- a/status_dashboard/open_dashboard.py
+++ b/status_dashboard/open_dashboard.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""桌面捷徑用的本機啟動器（2026-09-02 起，取代直接跑 `app.py`）。
+
+**主控板本身已經搬到協調 VM 上常駐執行**（見
+`docs/reference/CLOUD_WORKERS_IAP_SETUP.md`），本機不再自己起一份
+`app.py`——本機跟協調 VM 各跑一份會變成兩個互相不知道對方存在的
+「主控板」，資料各自為政（各自的 git 同步進度不同、各自看到不同的
+未分類程式清單），違背「所有人連同一份、同時看到同一份派工狀態」的
+整合目的。
+
+這支腳本改成單純負責：確認本機 `localhost:8866`有沒有一條活著的
+IAP tunnel 接到協調 VM，沒有就開一條，然後開瀏覽器。跟原本 `app.py`
+的角色分工乾淨切開——這支不碰任何主控板邏輯，只管「怎麼連上去」。
+
+**要更新主控板本身的程式碼**：協調 VM 上的 `app.py` 每次有人整理
+頁面都會自動 `git pull`（見 `sync_repo_from_github()`），拉到新 commit
+就自動重啟生效——PR 合併進 `main` 之後，下一次任何人重新整理頁面就會
+套用新版，不需要手動登入協調 VM 操作。`cloud_queue.py`／
+`iap_tunnel_manager.py` 沒有這套自動重啟（那兩支是常駐派工核心，
+自己重啟自己風險比較高，故意沒做），改了要手動 SSH 進去
+`git pull && sudo systemctl restart cloud-queue.service`。
+
+**不需要單一實例鎖**（跟 `app.py` 的 `acquire_lock()` 不一樣）：
+`gcloud compute start-iap-tunnel` 本身會真的綁定本機連接埠，兩個行程
+搶同一個埠時，第二個會直接因為 socket bind 失敗而結束，不會像
+`ThreadingHTTPServer`（預設 `allow_reuse_address=True`）那樣悄悄疊出
+多個都活著的行程——雙擊兩次頂多是第二次的 tunnel 嘗試白做工、可能
+多開一個瀏覽器分頁，不會真的疊出殘留行程。
+"""
+from __future__ import annotations
+
+import http.client
+import shutil
+import subprocess
+import sys
+import time
+import webbrowser
+from pathlib import Path
+
+# 桌面捷徑用 pyw（pythonw.exe）完全隱藏啟動，跟 app.py 同一個理由：
+# pyw 底下 sys.stdout/stderr 是 None，print() 會直接炸掉整支腳本
+# （這裡唯一會 print 的情況是 gcloud 找不到的錯誤訊息，但保險起見
+# 統一導向 log 檔，不要讓這種邊界情況變成一個沒人看得到的靜默崩潰）。
+if sys.stdout is None:
+    _log_f = open(Path(__file__).resolve().parent / "open_dashboard.log", "a",
+                 encoding="utf-8", buffering=1)
+    sys.stdout = _log_f
+    sys.stderr = _log_f
+
+# 協調 VM 的連線資訊——跟 `ssh_workers.json` 裡某個 worker 的三項辨識
+# （project/zone/instance）形式一樣，但這裡指的是「主控板本身所在的
+# 那台機器」，跟任何一個 worker 是不同概念，故意不共用同一份設定檔。
+PROJECT = "project-f6e2d0e1-cd17-4cfb-a9b"
+ZONE = "us-central1-a"
+INSTANCE = "instance-20260827-035250"
+PORT = 8866
+
+
+def _port_alive() -> bool:
+    try:
+        conn = http.client.HTTPConnection("127.0.0.1", PORT, timeout=1.5)
+        conn.request("HEAD", "/")
+        conn.getresponse()
+        return True
+    except OSError:
+        return False
+    finally:
+        try:
+            conn.close()
+        except Exception:  # noqa: BLE001, S110 — 連線物件都還沒建好時 close() 可能炸，忽略
+            pass
+
+
+def main() -> None:
+    if _port_alive():
+        webbrowser.open(f"http://127.0.0.1:{PORT}/")
+        return
+
+    # Windows 上 gcloud 是 gcloud.cmd（批次檔），不是 gcloud.exe——
+    # subprocess.Popen(["gcloud", ...]) 不加 shell=True 也不用
+    # shutil.which() 解析的話，Windows 的 CreateProcess 不會自動試
+    # PATHEXT 副檔名，會直接 FileNotFoundError（本機測試才踩到）。
+    # shutil.which() 找到的是完整路徑，含正確副檔名，兩個平台都適用，
+    # 不需要另外加 shell=True。
+    gcloud = shutil.which("gcloud")
+    if gcloud is None:
+        print("找不到 gcloud，請先安裝 Google Cloud SDK：https://cloud.google.com/sdk/docs/install",
+             flush=True)
+        return
+    subprocess.Popen(
+        [gcloud, "compute", "start-iap-tunnel", INSTANCE, str(PORT),
+         f"--local-host-port=localhost:{PORT}", f"--zone={ZONE}",
+         f"--project={PROJECT}"],
+        creationflags=subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+    # 等 tunnel 真的連上再開瀏覽器，不要開一個連不到的空頁面——IAP
+    # tunnel 首次建立通常幾秒內完成，20 秒是留給網路較慢或協調 VM
+    # 剛好在忙的寬裕上限。
+    for _ in range(20):
+        time.sleep(1)
+        if _port_alive():
+            break
+
+    webbrowser.open(f"http://127.0.0.1:{PORT}/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
使用者要求：雲端跟本機的主控板要整合成一份，大家連同一份、同時看到派工狀態，本機還要能雙擊直接開啟，且改動要能像現在這樣容易更新。

## 決策

本機不再自己起一份 `app.py`（會變成兩份互不知道對方存在的主控板）。唯一一份跑在協調 VM（`instance-20260827-035250`）上，所有人透過 IAP tunnel 連 `localhost:8866` 看同一份即時狀態——這正是專案原本設計 IAP tunnel 架構的目的，只是主控板本身之前沒真的照這個模式用。

## 新增

- `status_dashboard/open_dashboard.py`：本機啟動器。已連線就直接開瀏覽器，沒有就開一條 IAP tunnel、等連上、再開瀏覽器。不需要單一實例鎖——`gcloud start-iap-tunnel` 本身會綁定連接埠，第二個行程搶同一個埠會直接 bind 失敗結束。
- `launch_dashboard.vbs` 改呼叫這支新腳本。
- `CONTRIBUTING.md` 補上連線方式（IAP tunnel 指令、Windows 雙擊捷徑、macOS/Linux 怎麼比照）跟「怎麼更新主控板程式碼」的說明。

## 驗證

mock 掉 `webbrowser.open` 跑過完整流程，確認正確判斷「已連線」vs「需要開新 tunnel」，且新開的 tunnel 真的連得到協調 VM（HTTP 200）。過程中抓到一個真的 bug——Windows 上 `gcloud` 是 `.cmd` 批次檔，`subprocess.Popen(["gcloud", ...])` 不用 `shutil.which()` 解析會直接 `FileNotFoundError`——已修好並重新驗證。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>