### PR TITLE
[Claude] 修好自動同步被自己的 lock 檔永久卡住的 bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,14 @@ data/astrophys.csv
 # ============================================================
 logs/
 figs/
+# 2026-09-02：這兩個是主控板自己執行期間產生的，本來只是沒進版控
+# （從沒被 git add 過），沒有正式排除——直到發現未追蹤檔案會讓
+# sync_repo_from_github() 的「髒」判斷永遠卡住、自動同步從此失效
+# （見 app.py 那邊 --untracked-files=no 那次修正的說明），才正式排除，
+# 避免以後又靠「反正沒人 add」這種脆弱的默契。
+status_dashboard/dashboard.lock
+status_dashboard/dashboard_console.log
+status_dashboard/open_dashboard.log
 __pycache__/
 *.pyc
 prepared/

--- a/status_dashboard/app.py
+++ b/status_dashboard/app.py
@@ -345,7 +345,16 @@ def _sync_repo_from_github_uncached() -> dict:
             ahead, behind = counts.stdout.split()
             result["ahead"], result["behind"] = int(ahead), int(behind)
 
-        result["dirty"] = bool(_git("status", "--porcelain").stdout.strip())
+        # --untracked-files=no：只在意「有沒有修改過已追蹤的檔案」，不
+        # 管工作目錄裡有沒有未追蹤的雜項檔案——2026-09-02 實際踩到：
+        # acquire_lock() 自己寫的 status_dashboard/dashboard.lock、
+        # 別人手滑留下的殘餘檔案，都會被算進舊版的 --porcelain（含
+        # 未追蹤），讓這個判斷永遠卡在「髒」，自動同步從此完全失效、
+        # 而且沒有任何錯誤訊息——「落後幾個 commit 不動手」是刻意設計
+        # 的保護（怕蓋掉別人真正的未提交修改），但未追蹤的雜項檔案
+        # 不构成「別人正在改的東西」，不該一起算進去。
+        result["dirty"] = bool(
+            _git("status", "--porcelain", "--untracked-files=no").stdout.strip())
 
         if (result["branch"] == "main" and not result["dirty"]
                 and result["behind"] > 0):


### PR DESCRIPTION
實測發現：協調 VM 上的主控板已經好幾輪沒有自動 `git pull` 過。原因是 `sync_repo_from_github()` 的「乾淨」判斷用 `git status --porcelain`，這個指令預設也會把**未追蹤**的檔案算進去，而 `acquire_lock()` 自己會在 `status_dashboard/` 底下寫一個 `dashboard.lock`（單一實例鎖，主控板存活期間必然存在），加上協調 VM 上有幾個之前手滑留下的殘留檔案，永遠讓這個判斷卡在「髒」，自動同步因此永久失效，且沒有任何錯誤訊息提示這件事。

## 修法

改成 `git status --porcelain --untracked-files=no`，只在意有沒有修改過已追蹤的檔案——這才是原本設計要保護的「別人正在改的東西」，未追蹤的雜項檔案不构成這個風險。

順手把 `dashboard.lock`／`dashboard_console.log`／`open_dashboard.log` 補進 `.gitignore`。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>