### PR TITLE
[Claude] 主控板頁面秒開，即時探測改成背景非同步補上

### DIFF
--- a/status_dashboard/app.py
+++ b/status_dashboard/app.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import ast
 import ctypes
 import html
+import json
 import os
 import re
 import shlex
@@ -600,7 +601,14 @@ def _run_probes(to_probe: dict[str, dict]) -> dict[str, dict]:
     return _post_process_probes(to_probe, raw)
 
 
-def gather_status() -> dict:
+def gather_status(probe: bool = True) -> dict:
+    """`probe=False`：跳過所有即時探測（SSH／Kaggle API 呼叫），需要
+    探測的 label 一律標成 `state: "checking"`，其餘照舊——2026-09-02
+    使用者要求：頁面要先秒開，探測是背景後續的事，不要卡住整頁的回應
+    （之前是同一次請求裡做完所有探測才回應，最壞情況等到
+    `PROBE_DEADLINE_S`，工作閒置或連線本身較慢時很常見）。首頁走
+    `probe=False` 立刻回應，瀏覽器再用小段 JS 打 `/probe-status.json`
+    （用 `probe=True`）補上真正的狀態，見 `_PROBE_SCRIPT`。"""
     cloud_workers = cloud_queue.load_all_workers()
     cloud_items = {it["label"]: it for it in cloud_queue.read_queue()}
     cloud_done = parse_cloud_done()
@@ -621,7 +629,11 @@ def gather_status() -> dict:
             to_probe[label] = result
         else:
             label_status[label] = result
-    label_status.update(_run_probes(to_probe))
+    if probe:
+        label_status.update(_run_probes(to_probe))
+    else:
+        label_status.update({label: {"state": "checking", **info}
+                            for label, info in to_probe.items()})
 
     return {
         "alive": alive, "pid": pid,
@@ -630,7 +642,7 @@ def gather_status() -> dict:
     }
 
 
-def gather_worker_status() -> dict:
+def gather_worker_status(probe: bool = True) -> dict:
     """以雲端服務（worker）為單位，不是以步驟為單位——單純回答「這個
     worker 現在是不是真的在跑」（2026-08-25 使用者要求新增的第二種
     介面）。跟 `gather_status()` 是同一批來源資料的另一種切法，不重複
@@ -638,7 +650,10 @@ def gather_worker_status() -> dict:
     探測的是「這個 worker 上排定的第一個未完成 label」，`gather_status()`
     探測的是「stage_map.py 裡列出的每個 label」——兩邊在同一個 worker
     同時只有一個槽位在跑的前提下通常會對到同一個工作，但這支函式就算
-    stage_map.py 完全沒收錄某個 label，也照樣看得到。"""
+    stage_map.py 完全沒收錄某個 label，也照樣看得到。
+
+    `probe=False`：跟 `gather_status()` 同一個理由，見那邊的說明——
+    跳過所有即時探測，`/workers` 頁面秒開，JS 再補上真正的狀態。"""
     cloud_workers = cloud_queue.load_all_workers()
     cloud_items = {it["label"]: it for it in cloud_queue.read_queue()}
     cloud_done = parse_cloud_done()
@@ -666,6 +681,27 @@ def gather_worker_status() -> dict:
     idle_ssh = [name for name, kind in cloud_workers.items()
                if kind == "ssh" and name not in assigned]
 
+    if not probe:
+        # 秒開版：不打任何 SSH／Kaggle API，`to_probe`／`idle_ssh` 裡的
+        # worker 一律標成「探測中」，讓 _worker_badge() 顯示佔位樣式，
+        # 交給 JS 之後打 /workers-probe.json 補上真正結果。
+        workers_out = []
+        for name, kind in sorted(cloud_workers.items()):
+            if name in to_probe:
+                script = assigned[name].get("script") or None
+                workers_out.append({"name": name, "kind": kind, "assigned": True,
+                                    "state": "checking",
+                                    "label": assigned[name]["label"],
+                                    "script": script,
+                                    "args": assigned[name].get("args") or None})
+            elif name in idle_ssh:
+                workers_out.append({"name": name, "kind": kind, "assigned": False,
+                                    "checking": True})
+            else:
+                workers_out.append({"name": name, "kind": kind, "assigned": False,
+                                    "reachable": None})
+        return {"workers": workers_out}
+
     # 已派工的 worker（要探測工作狀態）跟閒置的 SSH worker（只要 ping）
     # 併成同一次 _run_concurrent() 呼叫，共用同一份 PROBE_DEADLINE_S——
     # 原本分兩次呼叫，各自都用完整預算，最壞情況（兩邊都連不上）整頁
@@ -692,10 +728,19 @@ def gather_worker_status() -> dict:
             # categorization.json，佇列檔自己就有 label→script 的對應，
             # 不需要另外維護一份索引才能知道「這個 worker 在跑哪支程式」，
             # 也不會因為新腳本還沒補進索引就看不到連結。
+            #
+            # args 也一併帶出來（同一次使用者反映）：像
+            # p6_lowmass_v3_s13/s15/s17 這種同一支腳本、切成多個 shard
+            # 平行跑的工作，光看腳本名稱三個都長一樣（本來就是同一支，
+            # 不是 bug），區分靠的是參數（--slopes 1.3/1.5/1.7 這種），
+            # 不帶出來的話連結旁邊看不出這幾個 worker 實際在算不同的
+            # 東西。
             script = assigned[name].get("script") or None
             workers_out.append({"name": name, "kind": kind, "assigned": True,
                                 "label": assigned[name]["label"],
-                                "script": script, **r})
+                                "script": script,
+                                "args": assigned[name].get("args") or None,
+                                **r})
         elif name in ping_results:
             p = ping_results[name]
             # _run_concurrent() 逾時/例外時的補值只有 status/error，沒有
@@ -721,7 +766,7 @@ def gather_worker_status() -> dict:
 
 STATE_LABEL = {
     "done_ok": "已完成", "done_fail": "失敗", "live": "進行中",
-    "pending": "待派工", "unknown": "沒有紀錄",
+    "pending": "待派工", "unknown": "沒有紀錄", "checking": "探測中",
 }
 
 
@@ -742,6 +787,12 @@ def _status_badge(st: dict) -> str:
         detail = "　".join(bits)
     elif state == "pending":
         cls, text, detail = "pending", "待派工", st.get("note", "")
+    elif state == "checking":
+        # 2026-09-02：頁面先秒開、探測結果用 JS 背景補上（見
+        # _PROBE_SCRIPT）——這是還沒補上之前的暫時樣子，不是真正的
+        # 狀態，所以用問號圖示跟中性配色，不要跟 pending／unknown 的
+        # 配色搞混（那兩個是「真的查過、結果就是這樣」）。
+        cls, text, detail = "checking", "探測中…", f"worker={st.get('worker', '?')}"
     else:
         cls, text, detail = "unknown", "沒有紀錄", st.get("note", "")
     return (f'<span class="badge {cls}">{html.escape(text)}</span>'
@@ -1170,8 +1221,9 @@ def render_html(status: dict, sync: dict | None = None) -> str:
                 if st is None:
                     continue
                 content_parts.append(
-                    f'<div class="status-row"><code>{html.escape(label)}</code>'
-                    f'{_status_badge(st)}</div>')
+                    f'<div class="status-row" data-label="{html.escape(label)}">'
+                    f'<code>{html.escape(label)}</code>'
+                    f'<span class="status-badge-slot">{_status_badge(st)}</span></div>')
 
             # 人工整理的解說層，順序是刻意的：先看「重點」知道這一步在
             # 幹嘛，再看「公式」知道實際在算什麼，再看「文獻出處」知道
@@ -1243,16 +1295,18 @@ def render_html(status: dict, sync: dict | None = None) -> str:
     parts.append("</div>")
 
     parts.append(_RESIZE_SCRIPT)
+    parts.append(_PROBE_SCRIPT)
     parts.append("</body></html>")
     return "".join(parts)
 
 
 # 左右欄寬度可拖曳（2026-08-25 使用者要求，像 IDE 的側欄一樣）。純
 # vanilla JS，沒有外部依賴；寬度存 localStorage，下次整理頁面／換頁
-# 還記得（不然每次都要重拖一次，形同沒有這個功能）。這是整個主控板
-# 唯一用到 JS 的地方——拖曳互動沒辦法用純 HTML/CSS 做到，其餘所有
-# 「不用手動展開」的需求都還是靠伺服器端 render + <details>，能不用
-# JS 就不用。
+# 還記得（不然每次都要重拖一次，形同沒有這個功能）。這是主控板第一個
+# 用到 JS 的地方——拖曳互動沒辦法用純 HTML/CSS 做到，其餘所有「不用
+# 手動展開」的需求都還是靠伺服器端 render + <details>，能不用 JS 就
+# 不用；`_PROBE_SCRIPT`（見下面）是第二個，理由同樣是純 HTML/CSS
+# 做不到「頁面先秒開、探測結果晚一點自己冒出來」這件事。
 _RESIZE_SCRIPT = """
 <script>
 (function () {
@@ -1286,22 +1340,55 @@ _RESIZE_SCRIPT = """
 </script>
 """
 
+# 頁面先秒開（server 端跳過即時探測，見 gather_status(probe=False)），
+# 載入後這段 JS 打 /probe-status.json 補上真正的狀態（2026-09-02 使用者
+# 要求）。回傳的是算好的 badge HTML 片段（見 _probe_status_json()），
+# 這裡只負責找到對應的 .status-badge-slot 塞進去，不重算任何邏輯——
+# 「怎麼畫一個 badge」只在 Python 維護一份。找不到對應 data-label 的
+# 項目（理論上不會發生，兩邊資料同一次請求算出來的）直接跳過，不報錯。
+_PROBE_SCRIPT = """
+<script>
+(function () {
+  fetch("/probe-status.json").then(function (r) { return r.json(); })
+    .then(function (data) {
+      document.querySelectorAll(".status-row[data-label]").forEach(function (row) {
+        var frag = data[row.dataset.label];
+        if (frag === undefined) return;
+        var slot = row.querySelector(".status-badge-slot");
+        if (slot) slot.innerHTML = frag;
+      });
+    })
+    .catch(function () { /* 探測失敗就維持「探測中」的樣子，不彈錯誤 */ });
+})();
+</script>
+"""
+
 
 _NAV = ('<nav class="nav"><a href="/">依步驟看</a>'
        '<a href="/workers">依雲端服務看</a></nav>')
 
 
 def _worker_label_html(w: dict) -> str:
-    """label 本身＋（有的話）它對應程式的可點連結。程式路徑直接來自
-    cloud_queue.txt 那一行（見 gather_worker_status()），不查任何索引。"""
+    """label 本身＋（有的話）它對應程式的可點連結＋執行參數。程式路徑
+    跟參數直接來自 cloud_queue.txt 那一行（見 gather_worker_status()），
+    不查任何索引。
+
+    參數要一起顯示：像 p6_lowmass_v3_s13/s15/s17 這種同一支腳本切成
+    多個 shard 平行跑的工作，光看腳本名稱三個都一樣（本來就是同一支，
+    不是 bug），區分靠的是參數（--slopes 1.3/1.5/1.7），不顯示的話
+    連結旁邊完全看不出這幾個 worker 實際在算不同的東西
+    （2026-09-02 使用者反映）。"""
     label_html = html.escape(w["label"])
     script = w.get("script")
     if not script:
         return label_html
+    args = w.get("args")
+    args_html = (f'<code class="worker-args">{html.escape(args)}</code>'
+                if args else "")
     return (f'{label_html}'
            f'<a class="script-link worker-script-link" '
            f'href="{html.escape(_doc_url(script))}"><code>'
-           f'{html.escape(script)}</code> ↗</a>')
+           f'{html.escape(script)}</code> ↗</a>{args_html}')
 
 
 def _worker_badge(w: dict) -> str:
@@ -1313,7 +1400,11 @@ def _worker_badge(w: dict) -> str:
     純文字，維持原本逐一逃逸。"""
     if w["assigned"]:
         state = w["state"]
-        if state == "live":
+        if state == "checking":
+            cls = "checking"
+            text = f"排定了 {_worker_label_html(w)}，探測中…"
+            detail = ""
+        elif state == "live":
             cls, text = "live", f"執行中：{_worker_label_html(w)}"
             bits = []
             if w.get("elapsed"):
@@ -1325,6 +1416,8 @@ def _worker_badge(w: dict) -> str:
             cls = "unknown"
             text = f"排定了 {_worker_label_html(w)}，但探測結果是「{html.escape(str(w.get('status', '?')))}」"
             detail = html.escape(w.get("note", w.get("error", "")))
+    elif w.get("checking"):
+        cls, text, detail = "checking", "探測中…", ""
     elif w.get("reachable") is True:
         cls, text, detail = "ok", "閒置中（機器連得上）", ""
     elif w.get("reachable") is False:
@@ -1368,12 +1461,35 @@ ping 一下確認連得上；Kaggle 帳號閒置時沒有常駐機器可以探�
 
     for w in workers:
         parts.append(
-            f'<div class="worker-row"><strong>{html.escape(w["name"])}</strong>'
+            f'<div class="worker-row" data-worker="{html.escape(w["name"])}">'
+            f'<strong>{html.escape(w["name"])}</strong>'
             f'<span class="kind">（{html.escape(w["kind"])}）</span>'
-            f'{_worker_badge(w)}</div>')
+            f'<span class="worker-badge-slot">{_worker_badge(w)}</span></div>')
 
+    parts.append(_WORKERS_PROBE_SCRIPT)
     parts.append("</body></html>")
     return "".join(parts)
+
+
+# 跟 _PROBE_SCRIPT 同一個理由、同一套做法，見那邊的說明——這裡對應的
+# 是 .worker-row[data-worker] / .worker-badge-slot，資料來源是
+# /workers-probe.json。
+_WORKERS_PROBE_SCRIPT = """
+<script>
+(function () {
+  fetch("/workers-probe.json").then(function (r) { return r.json(); })
+    .then(function (data) {
+      document.querySelectorAll(".worker-row[data-worker]").forEach(function (row) {
+        var frag = data[row.dataset.worker];
+        if (frag === undefined) return;
+        var slot = row.querySelector(".worker-badge-slot");
+        if (slot) slot.innerHTML = frag;
+      });
+    })
+    .catch(function () { /* 探測失敗就維持「探測中」的樣子，不彈錯誤 */ });
+})();
+</script>
+"""
 
 
 _CSS = """
@@ -1430,6 +1546,7 @@ h1 { font-size: 1.4em; margin-bottom: 0.2em; }
 .script-block { margin: 0.5em 0 0.5em 0.6em; }
 .script-link { font-size: 0.9em; text-decoration: none; }
 .worker-script-link { margin-left: 0.5em; font-size: 0.85em; }
+.worker-args { margin-left: 0.5em; font-size: 0.78em; color: #888; }
 .script-link:hover { text-decoration: underline; }
 /* 教學說明（重點／公式／文獻／核心程式碼）整層可收合，預設展開
    （2026-08-31 使用者要求）——跟下面 docstring 那個收合是同一種
@@ -1502,6 +1619,7 @@ mark.hl { background: rgba(255,214,0,0.35); color: inherit;
 .badge.live { background: rgba(200,140,0,0.2); }
 .badge.pending { background: rgba(128,128,128,0.15); }
 .badge.unknown { background: rgba(128,128,128,0.1); }
+.badge.checking { background: rgba(128,128,128,0.1); font-style: italic; }
 .detail { color: #777; font-size: 0.85em; }
 code { font-family: Consolas, monospace; }
 
@@ -1519,10 +1637,35 @@ code { font-family: Consolas, monospace; }
 
 # sync 只做一次、兩個路由共用——workers 頁不特別顯示同步狀態，但一樣
 # 從這次同步受益（資料層讀的是同一份 REPO_ROOT）。
+def _probe_status_json() -> str:
+    """`/` 頁面秒開後，JS 拿這個補上真正的探測結果（2026-09-02 使用者
+    要求）。回傳 {label: 這個 label 現在該顯示的 badge HTML} ——直接
+    回傳算好的 HTML 片段，不是原始狀態資料，是為了讓 badge 怎麼畫這件
+    事只在 Python（`_status_badge()`）維護一份，不要在 JS 那邊重寫一次
+    同樣的邏輯、之後兩邊各自改各自的、越改越不同步。"""
+    status = gather_status(probe=True)
+    label_status = status["label_status"]
+    fragments = {label: _status_badge(st) for label, st in label_status.items()}
+    return json.dumps(fragments, ensure_ascii=False)
+
+
+def _workers_probe_json() -> str:
+    """`/workers` 頁面版的 `_probe_status_json()`，同一個理由。"""
+    status = gather_worker_status(probe=True)
+    fragments = {w["name"]: _worker_badge(w) for w in status["workers"]}
+    return json.dumps(fragments, ensure_ascii=False)
+
+
 _ROUTES = {
-    "/": lambda sync: render_html(gather_status(), sync),
-    "/workers": lambda sync: render_workers_html(gather_worker_status()),
+    "/": lambda sync: render_html(gather_status(probe=False), sync),
+    "/workers": lambda sync: render_workers_html(gather_worker_status(probe=False)),
+    "/probe-status.json": lambda sync: _probe_status_json(),
+    "/workers-probe.json": lambda sync: _workers_probe_json(),
 }
+
+# 上面兩個 .json 路由回傳的是 application/json，不是 text/html——
+# do_GET() 用副檔名判斷，不用另外開一份路由表。
+_JSON_ROUTES = {"/probe-status.json", "/workers-probe.json"}
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -1539,16 +1682,21 @@ class Handler(BaseHTTPRequestHandler):
             self.send_response(404)
             self.end_headers()
             return
+        is_json = path in _JSON_ROUTES
         try:
             sync = sync_repo_from_github()
             body = route(sync).encode("utf-8")
         except Exception as e:  # noqa: BLE001 — 任何未預期例外都不該讓伺服器整個掛掉
             import traceback
             traceback.print_exc()
-            body = (f"<pre>整理狀態時發生錯誤：\n{html.escape(str(e))}\n\n"
-                    "看主控台的完整 traceback。</pre>").encode()
+            if is_json:
+                body = json.dumps({"_error": str(e)}).encode()
+            else:
+                body = (f"<pre>整理狀態時發生錯誤：\n{html.escape(str(e))}\n\n"
+                        "看主控台的完整 traceback。</pre>").encode()
         self.send_response(200)
-        self.send_header("Content-Type", "text/html; charset=utf-8")
+        content_type = "application/json; charset=utf-8" if is_json else "text/html; charset=utf-8"
+        self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))
         self.end_headers()
         self.wfile.write(body)


### PR DESCRIPTION
使用者要求：先讓主控板開啟，即時探測延後做——IAP tunnel 連上就立刻跳出分頁、顯示「探測中」，等探測好才顯示正確狀態。原本同一次請求要等完所有探測（最壞情況 25 秒）才回應。

## 做法

- `gather_status()`／`gather_worker_status()` 加 `probe` 參數，`probe=False` 跳過所有網路呼叫，需要探測的項目標成 `checking`。
- `/`、`/workers` 首頁改走 `probe=False`，本機測試從最壞 25 秒降到 1-2 秒。
- 新增 `/probe-status.json`、`/workers-probe.json`：`probe=True` 做真正探測，回傳算好的 badge HTML 片段（不是原始資料，避免 JS 重複維護一份渲染邏輯）。
- 兩個頁面各加一小段 JS，載入後 fetch 對應端點，補上 `data-label`／`data-worker` 對應的 slot。

順手處理另一個反映的問題：`/workers` 頁面同一支腳本切成多個 shard 跑時（例如 `p6_lowmass_v3_s13/s15/s17` 都是 `profile_lowmass.py`，只是 `--slopes` 不同），現在把參數也一併顯示，不然看不出差異。

## 驗證

本機真的用瀏覽器測過一輪：頁面秒開＋顯示「探測中」，背景 fetch 完成後用 JS 直接檢查 `document.querySelectorAll('.badge.checking')` 確認清零。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>