### PR TITLE
fix(H8): fit_real.py 漏排除已確認的非成員天體

### DIFF
--- a/fit_real.py
+++ b/fit_real.py
@@ -114,6 +114,7 @@ sys.path.insert(0, str(HERE))
 
 from pipeline import config as cfgmod, isochrones as isomod   # noqa: E402
 from pipeline import joint_fit, selection as selmod           # noqa: E402
+from pipeline import step5_imf                                # noqa: E402
 from pipeline.table_compat import Table                       # noqa: E402
 from measure_overconfidence import GRID                       # noqa: E402
 from injection_recovery import COARSE, multi_stage_best       # noqa: E402
@@ -312,6 +313,18 @@ def main():
     cfg = cfgmod.load()
     c3 = cfg.step3_age
     clean = Table.read(HERE / args.members_file, format="csv")
+    # 已確認的非成員天體（RV+logg 雙訊號，見 LIMITATIONS.md A6）——顏色跟
+    # 真成員無異，assign_masses() 的顏色檢查抓不到，只能靠這份獨立名單
+    # 排除。run_pipeline.py（第 4/5 步）與 traditional_accounting.py 都
+    # 已經接上這個機制，這支腳本（headline 前向模型數字的來源）先前漏接
+    # （2026-09-05 使用者回報查出），會讓 p2_final 系列等既有結果混入這
+    # 兩顆已確認非成員。
+    excl = step5_imf.exclude_confirmed_non_members(
+        np.asarray(clean["source_id"], np.int64))
+    if excl.any():
+        print(f"排除 {int(excl.sum())} 顆已確認非成員天體（見 "
+              f"LIMITATIONS.md A6）")
+    clean = clean[~excl]
     errmodel = dict(np.load(HERE / args.errmodel_file))
     grid = isomod.load_grid(isomod.CACHE / args.grid)
     plx = np.asarray(clean["parallax"], float)


### PR DESCRIPTION
## 問題（H8）
`run_pipeline.py`（第 4/5 步）與 `traditional_accounting.py` 都已呼叫 `pipeline/step5_imf.exclude_confirmed_non_members()`，排除 `LIMITATIONS.md` A6 記錄的兩顆已確認非成員天體（`64895139073954944`：RV 偏離 bulk_rv 19.5σ；`68409590552589184`：RV 偏離 bulk_rv 350σ，且不在 HR23 成員表裡）——這兩顆顏色跟真成員無異，`assign_masses()` 的顏色檢查抓不到，只能靠這份獨立名單排除。

但 `fit_real.py`——**headline 前向模型數字**（`p2_final`／`p9` 系列等既有結果）的產生腳本——讀 `cmd_members.csv` 之後從未呼叫這個排除機制，會把這兩顆已確認非成員一起餵進擬合。

## 修法
讀檔後立刻呼叫 `exclude_confirmed_non_members()` 排除，之後 `dm`／`color`／`mag`／徑向切片全部沿用排除後的樣本，跟 `run_pipeline.py` 的處理順序一致（`Table.__getitem__` 支援布林遮罩篩選，直接 `clean = clean[~excl]`）。

## 影響範圍
按 `RESOLVED.md`「原 A6」記載，這兩顆星對已核對的傳統法設定影響在小數點後兩位（例如 `alpha_naive` 從 1.9797→1.9603）。前向模型是否受同等量級影響，需要重跑 `p2_final` 系列才知道——這個 PR 只修程式碼路徑，不主張已知既有結果的具體偏差量。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>