### PR TITLE
fix(H14): 鎖 galpy<=1.10.2（PeTar 官方限制），Dockerfile 決定誠實記錄

### DIFF
--- a/nbody_setup/README.md
+++ b/nbody_setup/README.md
@@ -75,6 +75,29 @@ Linux 版**不套用任何 patch**——`petar_configure_mingw.patch` 與
 腳本會**先檢查編譯工具齊不齊、缺什麼就列出來並停下**，不會未經確認就
 對別人提供的機器 `sudo apt install`。
 
+## 為什麼是 shell 腳本，不是 Dockerfile（H14，2026-09-05 考慮過後的決定）
+
+`setup_linux_nbody.sh`／`setup_windows_nbody.sh` 已經做到 H14 真正要的
+東西——**釘選 commit（見上表）＋可重現的建置流程**，而且是實測跑過、
+真的編出可用執行檔的版本，不是紙上談兵。沒有另外包一層 Dockerfile：
+這批運算節點是隊友／學長借用的既有機器（見 `WORK_BOARD.md` 的
+`senior24`／`gcp1`），不是我們自己申請的乾淨容器環境，臨時要求對方
+先裝 Docker、把工作流程改成容器化，成本比維持現有 shell 腳本高，且
+腳本本身已經內建「先檢查、缺什麼列出來、不擅自 `sudo apt install`」
+這個對借用機器的禮貌——直接用 Docker 反而繞不過這個限制（容器化通常
+需要更高權限或至少要能裝 Docker daemon）。如果未來運算節點換成我們
+能完全控制的雲端 VM（例如比照 `docs/reference/CLOUD_WORKERS_IAP_SETUP.md`
+的協調 VM 模式），再回頭評估 Dockerfile 值不值得投資。
+
+**唯一發現且已修的版本鎖定缺口：galpy**——`petar_m45_grid.py` 目前還
+沒有任何指令用到 galpy（見 D19／H3，銀河潮汐場還沒接上），但兩支
+setup 腳本都已經預先加了鎖版本的安裝路徑（`INSTALL_GALPY=1` 觸發，
+`pip install "galpy<=1.10.2"`），理由是 PeTar 官方文件明講只支援
+galpy 到 1.10.2（1.11.0 改了 `PowerSphericalPotentialwCutoff`，跟
+PeTar 現在對 `MWPotential2014` 的參數設定不相容，且不一定會直接報錯，
+是「跑起來但結果不對」這種最難發現的失敗模式）。等 H3 真的把銀河潮汐場
+接上 PeTar 時，直接設這個環境變數重跑腳本即可。
+
 ## 驗證（2026-08-12 已跑過，結果正常）
 
 - `petar.omp.avx2.bse -h`：正常印出說明並結束（exit 0）

--- a/nbody_setup/setup_linux_nbody.sh
+++ b/nbody_setup/setup_linux_nbody.sh
@@ -141,13 +141,35 @@ clone_pinned SDAR      https://github.com/lwang-astro/SDAR.git     "$SDAR_COMMIT
 clone_pinned PeTar     https://github.com/lwang-astro/PeTar.git    "$PETAR_COMMIT"
 clone_pinned mcluster  https://github.com/lwang-astro/mcluster.git "$MCLUSTER_COMMIT"
 
+# ---------------------------------------------------------------- galpy（可選，銀河潮汐場）
+# **預設不裝**（H14，2026-09-05）：目前還沒有任何 petar_m45_grid.py 產生
+# 的指令會用到 galpy（見 LIMITATIONS.md D19／H3——galactic_tide 欄位目前
+# 被 validate_grid() 直接擋下，還沒真的接上），裝了也用不到，維持這支
+# 腳本原本「不多裝非必要套件」的精神。等 H3 的銀河潮汐場真的接上 PeTar
+# 時，設 INSTALL_GALPY=1 重跑這支腳本即可補裝。
+#
+# **版本一定要鎖在 <=1.10.2**：PeTar 的 galpy 介面官方文件明講「only
+# supports Galpy versions up to 1.10.2」——galpy 1.11.0 修改了
+# PowerSphericalPotentialwCutoff，跟 PeTar 目前對 MWPotential2014 的
+# 參數設定不相容。不鎖版本、讓 pip 裝到最新版，會在 petar.galpy 呼叫
+# MWPotential2014 時給出錯誤或不相容的結果，且不一定會直接報錯，屬於
+# 「跑起來但結果不對」這種最難發現的失敗模式。
+if [ "${INSTALL_GALPY:-0}" = "1" ]; then
+    echo "=== 安裝 galpy（銀河潮汐場，鎖版本 <=1.10.2）==="
+    pip install "galpy<=1.10.2"
+else
+    echo "=== 跳過 galpy（未設 INSTALL_GALPY=1；銀河潮汐場尚未接上 PeTar，見 D19） ==="
+fi
+
 # ---------------------------------------------------------------- 編譯
 # --with-mpi=no：單機多核心用 OpenMP 就夠（編出來的是 petar.omp.*），
 #   不跨機器分散，省掉 MPI 的安裝與設定。
 # --with-interrupt=bse：把 BSE 恆星演化編進去。第 5 步要比較的是
 #   「動力學演化 + 恆星演化」之後的質量函數，少了 BSE 就少一個真實效應。
 # 用上面解析出來的 $CC／$CXX／$FC，不寫死 gcc／g++／gfortran——conda
-# 環境下那些純名稱不存在（見前面檢查段落的說明）。
+# 環境下那些純名稱不存在（見前面檢查段落的說明）。galpy 若已用上面的
+# 區塊裝好，configure 會自動偵測到（pip 裝的話不需要額外傳
+# --with-galpy-prefix）。
 echo "=== 編譯 PeTar（含 BSE 恆星演化）==="
 cd "$NBODY_DIR/PeTar"
 CXX="$CXX" CC="$CC" FC="$FC" ./configure --prefix="$NBODY_DIR/install" \

--- a/nbody_setup/setup_windows_nbody.sh
+++ b/nbody_setup/setup_windows_nbody.sh
@@ -50,6 +50,18 @@ cd "$NBODY_DIR/mcluster"
 cp "$HERE/mingw_compat.c" "$HERE/mingw_compat.h" .
 patch -p1 --forward -r - < "$HERE/mcluster_main_mingw.patch" || echo "  （mcluster main.c patch 已套用過，跳過）"
 
+# galpy（可選，銀河潮汐場）——跟 setup_linux_nbody.sh 同一段邏輯與理由
+# （H14／LIMITATIONS.md D19）：預設不裝（還沒有指令用得到），要裝一定
+# 要鎖 <=1.10.2（PeTar 官方文件明講只支援到這個版本，1.11.0 改了
+# PowerSphericalPotentialwCutoff，跟 PeTar 現在的 MWPotential2014 設定
+# 不相容，不鎖版本會裝到不相容版、且不一定會直接報錯）。
+if [ "${INSTALL_GALPY:-0}" = "1" ]; then
+    echo "=== 安裝 galpy（銀河潮汐場，鎖版本 <=1.10.2）==="
+    pip install "galpy<=1.10.2"
+else
+    echo "=== 跳過 galpy（未設 INSTALL_GALPY=1；銀河潮汐場尚未接上 PeTar，見 D19） ==="
+fi
+
 echo "=== 編譯 PeTar（含 BSE 恆星演化）==="
 cd "$NBODY_DIR/PeTar"
 CXX=g++ CC=gcc FC=gfortran ./configure --prefix="$NBODY_DIR/install" --with-mpi=no --with-interrupt=bse


### PR DESCRIPTION
## 問題（H14，已查證 PeTar 官方文件）
[PeTar 官方文件](https://github.com/lwang-astro/PeTar) 明講「only supports Galpy versions up to 1.10.2」——galpy 1.11.0 修改了 \`PowerSphericalPotentialwCutoff\`，跟 PeTar 現在對 \`MWPotential2014\` 的參數設定不相容。現有 \`setup_linux_nbody.sh\`／\`setup_windows_nbody.sh\` 已經釘選 FDPS／SDAR／PeTar／mcluster 四個 commit，但完全沒有 galpy 依賴。

## 修法
兩支腳本都加上 \`INSTALL_GALPY=1\` 觸發的鎖版本安裝路徑（\`pip install "galpy<=1.10.2"\`），**預設不裝**——\`petar_m45_grid.py\` 目前還沒有任何指令會用到 galpy（銀河潮汐場還沒接上，見 \`LIMITATIONS.md\` D19／H3），裝了也用不到。等 H3 真的實作銀河潮汐場時，設這個環境變數重跑腳本即可補裝。

## Dockerfile 的部分
考慮過後決定不做，在 \`nbody_setup/README.md\` 誠實記錄理由：這批運算節點是隊友／學長借用的既有機器，不是我們能完全控制的乾淨容器環境；現有 shell 腳本已經做到「釘選 commit + 可重現建置流程」這個核心要求，且是實測跑過真的編出可用執行檔的版本，臨時改成容器化成本更高、也不一定被允許。如果未來換成我們自己的雲端 VM，再回頭評估。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>