### PR TITLE
fix(H12): 標準化網格動力學參數，補上缺漏的 Virial ratio

### DIFF
--- a/scripts/nbody_petar/petar_m45_grid.py
+++ b/scripts/nbody_petar/petar_m45_grid.py
@@ -1,5 +1,32 @@
 #!/usr/bin/env python
-"""Validate the M45 PeTar screening grid and render reproducible commands."""
+"""Validate the M45 PeTar screening grid and render reproducible commands.
+
+H12（2026-09-05，參數標準化，查證 mcluster 官方 README 確認）：
+
+- `mcluster_S` is mcluster's ``-S`` flag: "degree of mass segregation
+  (0.0-1.0, 0.0=no segregation)" -- the SAME physical quantity as
+  Converse & Stahler (2010) Table 1's segregation parameter beta
+  (0.5 +/- 0.3), not a fractal dimension. mcluster's fractal dimension
+  is a *different* flag, ``-D`` (1.6-3.0, 3.0=no fractalization), which
+  this grid does not expose as a column and never passes -- do not
+  confuse the two when reading mcluster's own docs, the flag letters
+  are easy to mix up.
+- ``profile`` (mcluster's ``-P``): 0=Plummer, 2=Subr et al. (2007)
+  mass-segregated profile (this grid never uses 1=King or 3=EFF/Nuker).
+  This is a *different* modeling choice from the King/Woolley/Wilson
+  dynamical-equilibrium models compared in
+  ``scripts/diagnostics/limepy_multimass.py`` (route D, LIMITATIONS.md
+  B5) -- the two are unrelated axes answering different questions
+  (initial density-profile shape for an N-body IC vs. present-day
+  equilibrium-model fit to observed density), not something that needs
+  to agree with each other.
+- Virial ratio (mcluster's ``-Q``) was never set, so every run silently
+  used whatever mcluster's compiled-in default is -- mcluster's own
+  README documents no default value for ``-Q``. C&S's initial state is
+  explicitly virial equilibrium (Q=0.5), so ``render_commands()`` now
+  passes ``-Q 0.50`` explicitly instead of relying on an unverified
+  default.
+"""
 from __future__ import annotations
 
 import argparse
@@ -90,6 +117,12 @@ def render_commands(row: dict) -> str:
         "-B", str(row["n_binaries"]),
         "-P", str(row["profile"]),
         "-R", f"{row['half_mass_radius_pc']:.2f}",
+        # H12: mcluster's README documents no default for -Q, so leaving
+        # it unset means every run silently used whatever the compiled
+        # binary's own internal default happens to be. C&S's initial
+        # state is explicitly virial equilibrium (Q=0.5), so pass it
+        # explicitly instead of relying on an unverified default.
+        "-Q", "0.50",
         "-f", "1",
         "-C", "5",
         "-u", "1",
@@ -98,7 +131,10 @@ def render_commands(row: dict) -> str:
         "-o", row["run_id"],
     ]
     if row["profile"] == 2:
-        command[9:9] = ["-S", f"{row['mcluster_S']:.2f}"]
+        # -S is mass segregation degree (not a fractal dimension --
+        # see module docstring), only meaningful for the Subr et al.
+        # (2007) mass-segregated profile (-P 2). Insert right before -f.
+        command[11:11] = ["-S", f"{row['mcluster_S']:.2f}"]
     mcluster = " ".join(shlex.quote(part) for part in command)
     return "\n".join(
         [


### PR DESCRIPTION
## 問題（H12，已查證 mcluster 官方 README）

1. **Virial ratio 缺漏**：\`-Q\`（virial ratio）從沒被設定過。mcluster README 沒有記載 \`-Q\` 的預設值，等於每次跑都在信任一個沒查證過的內建預設。
2. **\`mcluster_S\` 容易被誤認成分形參數**：查證 mcluster README 確認 \`-S\` 的真正定義是「degree of mass segregation」（跟 C&S Table 1 的 β 是同一個物理量），分形維度其實是另一個完全不同的旗標 \`-D\`（1.6-3.0），這個網格從未使用。
3. **Plummer／King 混用的疑慮**：\`profile\`（\`-P\`）目前只用 0（Plummer）與 2（Subr et al. 2007 質量分層剖面），從未用過 1（King）。真正的 King/Woolley/Wilson 比較在 \`scripts/diagnostics/limepy_multimass.py\`（route D），是完全不同的建模軸，不需要跟 route C 的初始密度剖面一致。

## 修法
- \`render_commands()\` 加上明確的 \`-Q 0.50\`（C&S 的初始狀態是 virial 平衡）。
- 模組 docstring 寫清楚 \`-S\` vs \`-D\`、\`profile\` 0/2 vs route D 的 King/Woolley/Wilson 分別對應什麼，避免以後又混淆。
- 修正 \`-S\` 旗標插入的索引（新增 \`-Q\` 兩個元素後從 \`command[9:9]\` 改成 \`command[11:11]\`），已驗證 profile=0／2 兩種情況產生的指令都正確，\`validate_grid()\` 無回歸。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>